### PR TITLE
QuickFix: tensorpac function call in sw_detect

### DIFF
--- a/yasa/main.py
+++ b/yasa/main.py
@@ -1230,7 +1230,7 @@ def sw_detect(data, sf=None, ch_names=None, hypno=None, include=(2, 3),
             pha_at_max_full[idx_nomask] = pha_at_max
             sw_params['PhaseAtSigmaPeak'] = pha_at_max_full
             # Normalized Direct PAC, without thresholding
-            ndp = tpm.ndpac(sw_pha_ev[None, ...], sp_amp_ev[None, ...], p=1)
+            ndp = tpm.norm_direct_pac(sw_pha_ev[None, ...], sp_amp_ev[None, ...], p=1)
             ndp = np.squeeze(ndp)
             ndp_full = np.ones(n_peaks) * np.nan
             ndp_full[idx_nomask] = ndp


### PR DESCRIPTION
`tensorpac` package changes their API [?] and their `tpm.ndpac` is now `tpm.norm_direct_pac`