### PR TITLE
Inform user about resampled fitting range

### DIFF
--- a/yasa/spectral.py
+++ b/yasa/spectral.py
@@ -484,8 +484,8 @@ def irasa(data, sf=None, ch_names=None, band=(1, 30),
             ch_names = np.atleast_1d(np.asarray(ch_names, dtype=str))
             assert ch_names.ndim == 1, 'ch_names must be 1D.'
             assert len(ch_names) == nchan, 'ch_names must match data.shape[0].'
-        hp = None  # Highpass filter unknown
-        lp = None  # Lowpass filter unknown
+        hp = 0  # Highpass filter unknown -> set to 0 Hz
+        lp = sf / 2  # Lowpass filter unknown -> set to Nyquist
 
     # Check the other arguments
     hset = np.asarray(hset)
@@ -506,12 +506,12 @@ def irasa(data, sf=None, ch_names=None, band=(1, 30),
           f"{band[0]:.2f}Hz-{band[1]:.2f}Hz")
     logging.info("Evaluated frequency range: "
           f"{band_evaluated[0]:.2f}Hz-{band_evaluated[1]:.2f}Hz")
-    if hp and band_evaluated[0] < hp:
+    if band_evaluated[0] < hp:
         logging.warning("The evaluated frequency range starts below the "
                         f"highpass filter ({hp:.2f}Hz). Increase the lower band"
                         f" ({band[0]:.2f}Hz) or decrease the maximum value of "
                         f"the hset ({h_max:.2f}).")
-    if lp and band_evaluated[1] > lp:
+    if band_evaluated[1] > lp and lp < freq_Nyq_res:
         logging.warning("The evaluated frequency range ends after the "
                         f"lowpass filter ({lp:.2f}Hz). Decrease the upper band"
                         f" ({band[1]:.2f}Hz) or decrease the maximum value of "


### PR DESCRIPTION
### What is the problem?
IRASA works by resampling the time series for different h-values of a given h-set. The oscillatory peaks are shifted up and down and can thus be eliminated. This resampling procedure can be quite dangerous though if frequency ranges of the PSD are evaluated which should not be evaluated. This corresponds to challenge 1 (page 16) in [1]. 

For example, when using a 1 Hz highpass filter, one should not use a fitting range from 1-100Hz because using the default h-set (with the maximum resampling factor being ca. h_max=2), a frequency range of ca. 0.5-200Hz will be evaluated. This includes the highpass filtered range which should be avoided. See Fig. 5 b) in [1].

The equation to calculate the evaluated fitting range (in contrast to the fitting range) is given on page 17 of [1]. 

### What is the solution?
I inserted a few lines of code that explicitly inform the user about the evaluated fitting range. That might be enough to give the user a better idea of which part of the PSD IRASA actually evaluates. 

### Reference
[1] Separating neural oscillations from aperiodic 1/f activity: challenges and recommendations
Moritz Gerster, Gunnar Waterstraat, Vladimir Litvak, Klaus Lehnertz, Alfons Schnitzler, Esther Florin, Gabriel Curio, Vadim Nikulin
bioRxiv 2021.10.15.464483; doi: https://doi.org/10.1101/2021.10.15.464483