### PR TITLE
Add two new functions: a) find periods in hypnogram and b) heart rate by stage

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -44,7 +44,7 @@ Hypnogram & sleep statistics
 Spectral analyses
 -----------------
 
-.. _others:
+.. _spectral:
 
 .. autosummary::
    :toctree: generated/
@@ -58,3 +58,14 @@ Spectral analyses
     sliding_window
     stft_power
     topoplot
+
+
+Heart rate analysis
+-------------------
+
+.. _others:
+
+.. autosummary::
+   :toctree: generated/
+
+    hrv_stage

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,6 +34,7 @@ Hypnogram & sleep statistics
     hypno_upsample_to_sf
     hypno_str_to_int
     hypno_int_to_str
+    hypno_find_periods
     load_profusion_hypno
     plot_hypnogram
     plot_spectrogram

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,7 +13,13 @@ v0.6.2.dev
 
 **New functions**
 
-a. Added the :py:func:`yasa.hypno_find_periods` function to find sequences of consecutive values in hypnogram that are longer than a certain duration. This function can be used to detect NREM/REM periods.
+a. Added the :py:func:`yasa.hypno_find_periods` function to find sequences of consecutive values in hypnogram that are longer than a certain duration. This is a flexible function that can be used to detect NREM/REM periods.
+b. Added the :py:func:`hrv_stage` function, which calculates heart rate (HR) and heart rate variability (HRV) by stage and periods. The epochs are found using the newly-added :py:func:`yasa.hypno_find_periods` function.
+c. Added a new dataset containing 8 hours of ECG data. The dataset is in compressed NumPy format and can be found in notebooks/data_ECG_8hrs_200Hz.npz. The dataset also includes an upsampled hypnogram.
+
+**Dependencies**
+
+a. Added `SleepECG <https://sleepecg.readthedocs.io/en/stable/>`_ to the dependencies. SleepECG is used for the heartbeats detection in :py:func:`hrv_stage`.
 
 v0.6.1 (March 2022)
 -------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,12 +14,12 @@ v0.6.2.dev
 **New functions**
 
 a. Added the :py:func:`yasa.hypno_find_periods` function to find sequences of consecutive values in hypnogram that are longer than a certain duration. This is a flexible function that can be used to detect NREM/REM periods.
-b. Added the :py:func:`hrv_stage` function, which calculates heart rate (HR) and heart rate variability (HRV) by stage and periods. The epochs are found using the newly-added :py:func:`yasa.hypno_find_periods` function.
+b. Added the :py:func:`yasa.hrv_stage` function, which calculates heart rate (HR) and heart rate variability (HRV) by stage and periods. The epochs are found using the newly-added :py:func:`yasa.hypno_find_periods` function.
 c. Added a new dataset containing 8 hours of ECG data. The dataset is in compressed NumPy format and can be found in notebooks/data_ECG_8hrs_200Hz.npz. The dataset also includes an upsampled hypnogram.
 
 **Dependencies**
 
-a. Added `SleepECG <https://sleepecg.readthedocs.io/en/stable/>`_ to the dependencies. SleepECG is used for the heartbeats detection in :py:func:`hrv_stage`.
+a. Added `SleepECG <https://sleepecg.readthedocs.io/en/stable/>`_ to the dependencies. SleepECG is used for the heartbeats detection in :py:func:`yasa.hrv_stage`.
 
 v0.6.1 (March 2022)
 -------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,13 @@ What's new
 
 ----------------------------------------------------------------------------------------
 
+v0.6.2.dev
+----------
+
+**New functions**
+
+a. Added the :py:func:`yasa.hypno_find_periods` function to find sequences of consecutive values in hypnogram that are longer than a certain duration. This function can be used to detect NREM/REM periods.
+
 v0.6.1 (March 2022)
 -------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ lspopt
 tensorpac>=0.6.5
 scikit-learn
 pyriemann>=0.2.7
+sleepecg>=0.5.0
 joblib
 antropy
 lightgbm

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ INSTALL_REQUIRES = [
     'scikit-learn',
     'tensorpac>=0.6.5',
     'pyriemann>=0.2.7',
+    'sleepecg>=0.5.0',
     'lspopt',
     'ipywidgets',
     'joblib'

--- a/yasa/__init__.py
+++ b/yasa/__init__.py
@@ -1,6 +1,7 @@
 import logging
 from .detection import *
 from .features import *
+from .heart import *
 from .hypno import *
 from .numba import *
 from .others import *

--- a/yasa/detection.py
+++ b/yasa/detection.py
@@ -43,6 +43,7 @@ def _check_data_hypno(data, sf=None, ch_names=None, hypno=None, include=None, ch
         data = data.get_data() * 1e6  # Convert from V to uV
     else:
         assert sf is not None, 'sf must be specified if not using MNE Raw.'
+        assert isinstance(sf, (int, float)), "sf must be int or float."
     data = np.asarray(data, dtype=np.float64)
     assert data.ndim in [1, 2], 'data must be 1D (times) or 2D (chan, times).'
     if data.ndim == 1:

--- a/yasa/detection.py
+++ b/yasa/detection.py
@@ -43,6 +43,8 @@ def _check_data_hypno(data, sf=None, ch_names=None, hypno=None, include=None, ch
         data = data.get_data() * 1e6  # Convert from V to uV
     else:
         assert sf is not None, 'sf must be specified if not using MNE Raw.'
+        if isinstance(sf, np.ndarray):  # Deal with sf = array(100.) --> 100
+            sf = float(sf)
         assert isinstance(sf, (int, float)), "sf must be int or float."
     data = np.asarray(data, dtype=np.float64)
     assert data.ndim in [1, 2], 'data must be 1D (times) or 2D (chan, times).'

--- a/yasa/heart.py
+++ b/yasa/heart.py
@@ -1,0 +1,177 @@
+"""
+ECG-based functions.
+
+Author: Dr Raphael Vallat <raphaelvallat@berkeley.edu>, UC Berkeley.
+Date: May 2022
+"""
+import logging
+import numpy as np
+import pandas as pd
+
+from .hypno import hypno_find_periods
+from .detection import _check_data_hypno
+from .io import set_log_level, is_sleepecg_installed
+
+logger = logging.getLogger('yasa')
+
+__all__ = ['hrv_stage']
+
+
+def hrv_stage(data, sf, *, hypno=None, include=(2, 3, 4), threshold="2min", equal_length=False,
+              rr_limit=(400, 2000), verbose=False):
+    """Calculate heart rate and heart rate variability (HRV) features from an ECG.
+
+    By default, the cardiac features are calculated for each period of N2, N3 or REM sleep that
+    are longer than 2 minutes.
+
+    .. versionadded:: 0.6.2
+
+    Parameters
+    ----------
+    data : :py:class:`numpy.ndarray`
+        Single-channel ECG data. Must be a 1D NumPy array.
+    sf : float
+        The sampling frequency of the data.
+    hypno : array_like
+        Sleep stage (hypnogram). The heart rate calculation will be applied for each sleep stage
+        defined in ``include`` (default = N2, N3 and REM sleep separately).
+
+        The hypnogram must have the same number of samples as ``data``.
+        To upsample your hypnogram, please refer to
+        :py:func:`yasa.hypno_upsample_to_data`.
+
+        .. note::
+            The default hypnogram format in YASA is a 1D integer
+            vector where:
+
+            - -2 = Unscored
+            - -1 = Artefact / Movement
+            - 0 = Wake
+            - 1 = N1 sleep
+            - 2 = N2 sleep
+            - 3 = N3 sleep
+            - 4 = REM sleep
+    include : tuple, list or int
+        Values in ``hypno`` that will be included in the mask. The default is
+        (2, 3, 4), meaning that the detection is applied on N2, N3 and REM
+        sleep separately.
+    threshold : str
+        Only periods of a given stage that exceed the duration defined in ``threshold`` will be
+        kept in subsequent analysis. The default is 2 minutes ('2min'). Other possible values
+        include: '5min', '15min', '30sec', '1hour', etc. To disable thresholding, use '0min'.
+    equal_length : bool
+        If True, the periods will all have the exact duration defined in ``threshold``.
+        That is, periods that are longer than the duration threshold will be divided into
+        sub-periods of exactly the length of threshold.
+    rr_limit : tuple
+        Lower and upper limit for the RR interval. Default is 400 to 2000 ms, corresponding to a
+        heart rate of 30 to 150 bpm. RR intervals outside this range will be set to NaN and
+        filled with linear interpolation. Use ``rr_limit=(0, np.inf)`` to disable RR correction.
+    verbose : bool or str
+        Verbose level. Default (False) will only print warning and error
+        messages. The logging levels are 'debug', 'info', 'warning', 'error',
+        and 'critical'. For most users the choice is between 'info'
+        (or ``verbose=True``) and warning (``verbose=False``). Set this to True if you are getting
+        invalid results and want to better understand what is happening.
+
+    Returns
+    -------
+    epochs : :py:class:`pandas.DataFrame`
+        Output dataframe with stage and epoch number as index. The columns are
+
+        * 'start' : The start of the epoch, in seconds from the beginning of the recording.
+        * 'duration' : The duration of the epoch, in seconds.
+        * 'hr_mean': The mean heart rate (HR) across the epoch, in beats per minute (bpm).
+        * 'hr_std': The standard deviation of the HR across the epoch, in bpm
+        * 'hrv_rmssd': Heart rate variability across the epoch (RMSSD), in milliseconds.
+    rpeaks : dict
+        A dictionary with the detected heartbeats (R-peaks) indices for each epoch of each stage.
+        Indices are expressed as samples from the beginning of the epoch. This can be used to
+        manually recalculate the RR intervals, apply a custom preprocessing on the RR intervals,
+        and/or calculate more advanced HRV metrics.
+
+    Notes
+    -----
+    This function returns three cardiac features for each epoch: the mean and standard deviation of
+    the heart rate, and the root mean square of successive differences between normal heartbeats
+    (RMSSD). The RMSSD reflects the beat-to-beat variance in HR and is the primary time-domain
+    measure used to estimate the vagally mediated changes reflected in heart rate variability.
+
+    Heartbeat detection is performed with the SleepECG library: https://github.com/cbrnr/sleepecg
+
+    References
+    ----------
+    * Shaffer, F., & Ginsberg, J. P. (2017). An overview of heart rate variability metrics and
+      norms. Frontiers in public health, 258.
+    """
+    set_log_level(verbose)
+    is_sleepecg_installed()
+    from sleepecg import detect_heartbeats
+
+    if isinstance(hypno, type(None)):
+        logger.warning("No hypnogram was passed. The entire recording will be used.")
+        data = np.asarray(data, dtype=np.float64)
+        hypno = np.zeros(max(data.shape), dtype=int)
+        include = 0
+
+    # Safety check
+    (data, sf, _, hypno, include, _, n_chan, n_samples, _
+     ) = _check_data_hypno(data, sf, None, hypno, include, check_amp=False)
+    assert n_chan == 1, "data must be a 1D ECG array."
+    data = np.squeeze(data)
+
+    # Find periods of equal duration
+    epochs = hypno_find_periods(hypno, sf, threshold=threshold, equal_length=equal_length)
+    assert epochs.shape[0] > 0, f"No epochs longer than {threshold} found in hypnogram."
+    epochs = epochs[epochs["values"].isin(include)].reset_index(drop=True)
+    # Sort by stage and add epoch number
+    epochs.sort_values(by=['values', 'start'], inplace=True)
+    epochs['epoch'] = epochs.groupby("values")["start"].transform(lambda x: range(len(x)))
+    epochs.set_index(["values", "epoch"], inplace=True)
+
+    # Loop over epochs
+    rpeaks = {}
+    for idx in epochs.index:
+        start = epochs.loc[idx, "start"]
+        duration = epochs.loc[idx, "length"]
+        end = int(epochs.loc[idx, "start"] + duration)
+        # Detect R-peaks
+        try:
+            pks = detect_heartbeats(data[start:end], fs=sf)
+        except Exception as e:
+            logger.info(f"Heartbeat detection failed for epoch {idx[1]} of stage {idx[0]}: {e}")
+            continue
+
+        # Save rpeaks to dict
+        rpeaks[idx] = pks
+
+        # If not enough R-peaks were detected, skip epochs and return NaN
+        # Here, we assume a minimal HR of 30 bpm
+        constant_hr = 60 * (pks.size / (duration / sf))
+        if constant_hr < 30:
+            logger.info(f"Too few detected heartbeats in epoch {idx[1]} of stage {idx[0]}.")
+            continue
+
+        # Find and correct RR intervals. Default is 400 ms (150 bpm) to 2000 ms (30 bpm)
+        rri = 1000 * np.diff(pks) / sf
+        rri = np.ma.masked_outside(rri, rr_limit[0], rr_limit[1]).filled(np.nan)
+        # Interpolate NaN values, but no more than 10 consecutive values
+        if np.isnan(rri).any():
+            rri = pd.Series(rri).interpolate(limit_direction="both", limit=10).to_numpy()
+        if np.isnan(rri).any():
+            # If there are still NaN present, skip current epoch
+            logger.info(f"Invalid RR intervals in epoch {idx[1]} of stage {idx[0]}.")
+            continue
+
+        # Heart rate
+        hr = 60000 / rri
+        epochs.loc[idx, "hr_mean"] = np.mean(hr)
+        epochs.loc[idx, "hr_std"] = np.std(hr, ddof=1)
+        epochs.loc[idx, "hrv_rmssd"] = np.sqrt(np.mean(np.diff(rri)**2))
+
+    # Convert start and duration to seconds
+    epochs['start'] /= sf
+    epochs['length'] /= sf
+    epochs.rename(columns={"length": "duration"}, inplace=True)
+
+    return epochs, rpeaks

--- a/yasa/hypno.py
+++ b/yasa/hypno.py
@@ -322,11 +322,11 @@ def hypno_find_periods(hypno, sf_hypno, threshold="5min", equal_length=False):
     Returns
     -------
     periods : :py:class:`pandas.DataFrame`
-        Output dataframe::
+        Output dataframe
 
-            'values' : The value in hypno of the current period
-            'start' : The index of the start of the period in hypno
-            'length' : The duration of the period, in number of samples
+        * 'values' : The value in hypno of the current period
+        * 'start' : The index of the start of the period in hypno
+        * 'length' : The duration of the period, in number of samples
 
     Examples
     --------
@@ -367,7 +367,7 @@ def hypno_find_periods(hypno, sf_hypno, threshold="5min", equal_length=False):
     1       2      5       6
     2       0     11       3
 
-    Lastly, using ``equal_length=True` will further divide the periods into segments of the
+    Lastly, using ``equal_length=True`` will further divide the periods into segments of the
     same duration, i.e. the duration defined in ``threshold``:
 
     >>> hypno = [0, 0, 0, 0, 1, 2, 2, 2, 2, 2, 2, 0, 0, 0, 1, 0, 1]

--- a/yasa/hypno.py
+++ b/yasa/hypno.py
@@ -413,7 +413,7 @@ def hypno_find_periods(hypno, sf_hypno, threshold="5min", equal_length=False):
     run_lengths = np.diff(np.append(run_starts, n))
     seq = pd.DataFrame({'values': run_values, 'start': run_starts, 'length': run_lengths})
 
-    # Remove run that are shorter than threshold
+    # Remove runs that are shorter than threshold
     seq = seq[seq['length'] >= thr_samp].reset_index(drop=True)
 
     if not equal_length:

--- a/yasa/hypno.py
+++ b/yasa/hypno.py
@@ -314,7 +314,7 @@ def hypno_find_periods(hypno, sf_hypno, threshold="5min", equal_length=False):
     threshold : str
         This function will only keep periods that exceed a certain duration (default '5min'), e.g.
         '5min', '15min', '30sec', '1hour'. To disable thresholding, use '0sec'.
-    equal_length: bool
+    equal_length : bool
         If True, the periods will all have the exact duration defined
         in threshold. That is, periods that are longer than the duration threshold will be divided
         into sub-periods of exactly the length of ``threshold``.

--- a/yasa/hypno.py
+++ b/yasa/hypno.py
@@ -405,7 +405,7 @@ def hypno_find_periods(hypno, sf_hypno, threshold="5min", equal_length=False):
     n = x.shape[0]
     loc_run_start = np.empty(n, dtype=bool)
     loc_run_start[0] = True
-    np.not_equal(x[:-1], x[1:], out=loc_run_start[1:])
+    loc_run_start[1:] = x[:-1] != x[1:]
     run_starts = np.nonzero(loc_run_start)[0]
     # Find run values
     run_values = x[loc_run_start]

--- a/yasa/io.py
+++ b/yasa/io.py
@@ -45,3 +45,11 @@ def is_pyriemann_installed():
         import pyriemann  # noqa
     except IOError:  # pragma: no cover
         raise IOError("pyRiemann needs to be installed. Please use `pip install pyriemann -U`.")
+
+
+def is_sleepecg_installed():
+    """Test if sleepecg is installed."""
+    try:
+        import sleepecg  # noqa
+    except IOError:  # pragma: no cover
+        raise IOError("sleepecg needs to be installed. Please use `pip install sleepecg -U`.")

--- a/yasa/tests/test_heart.py
+++ b/yasa/tests/test_heart.py
@@ -1,0 +1,53 @@
+"""Test the functions in the yasa/heart.py file."""
+import unittest
+import numpy as np
+from yasa.heart import hrv_stage
+
+# Load data
+ecg_file = np.load("notebooks/data_ECG_8hrs_200Hz.npz")
+data = ecg_file["data"]
+sf = int(ecg_file["sf"])
+hypno = ecg_file["hypno"]
+
+
+class TestHeart(unittest.TestCase):
+
+    def test_hrv_stage(self):
+        """Test function hrv_stage"""
+        epochs, rpeaks = hrv_stage(data, sf, hypno=hypno)
+        assert epochs.shape[0] == len(rpeaks)
+        assert epochs["duration"].min() == 120  # 2 minutes
+        assert np.array_equal(
+            epochs.columns, ['start', 'duration', 'hr_mean', 'hr_std', 'hrv_rmssd'])
+
+        # Only N2
+        epochs_N2, _ = hrv_stage(data, sf, hypno=hypno, include=2)
+        assert epochs.xs(2, drop_level=False).equals(epochs_N2)
+
+        # Disabling RR correction
+        epochs_norr, _ = hrv_stage(data, sf, hypno=hypno, rr_limit=(0, np.inf))
+        assert not epochs.equals(epochs_norr)
+
+        # Disabling the duration threshold
+        epochs_nothresh, _ = hrv_stage(data, sf, hypno=hypno, threshold="0min")
+        assert epochs_nothresh.shape[0] > epochs.shape[0]
+        assert epochs_nothresh["duration"].min() == 30  # 1 epoch
+
+        # Equal length
+        epochs_eq, _ = hrv_stage(data, sf, hypno=hypno, threshold="5min", equal_length=True)
+        assert epochs_eq["duration"].nunique() == 1
+        assert epochs_eq["duration"].unique()[0] == 300
+
+        # No hypno (= full recording)
+        # The heartbeat detection is applied on the entire recording!
+        epochs_nohypno, _ = hrv_stage(data, sf)
+        assert epochs_nohypno.shape[0] == 1
+        assert epochs_nohypno.loc[(0, 0), 'duration'] == data.size / sf
+
+        # No hypno (= full recording) with equal_length
+        # Equivalent to a sliding window approach
+        epochs_nohypno, _ = hrv_stage(
+            data, sf, equal_length=True)
+        assert epochs_nohypno['start'].is_monotonic_increasing
+        assert epochs_nohypno['duration'].nunique() == 1
+        assert epochs_nohypno.shape[0] == data.size / (2 * 60 * sf)  # 2 minutes

--- a/yasa/tests/test_hypno.py
+++ b/yasa/tests/test_hypno.py
@@ -3,6 +3,7 @@ import mne
 import unittest
 import numpy as np
 import pandas as pd
+from pandas.testing import assert_frame_equal
 from yasa.hypno import (hypno_str_to_int, hypno_int_to_str,
                         hypno_upsample_to_sf, hypno_fit_to_data,
                         hypno_upsample_to_data)
@@ -78,12 +79,12 @@ class TestHypno(unittest.TestCase):
             'start': [0, 11, 14, 16, 25],
             'length': [11, 3, 2, 9, 2]})
 
-        assert hfp(x, sf_hypno=1 / 60, threshold="0min").equals(expected)
-        assert hfp(x, sf_hypno=1, threshold="0min").equals(expected)
+        assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="0min"), expected)
+        assert_frame_equal(hfp(x, sf_hypno=1, threshold="0min"), expected)
 
         # 1b. With thresholding
         expected = pd.DataFrame({'values': [0, 1], 'start': [0, 16], 'length': [11, 9]})
-        assert hfp(x, sf_hypno=1 / 60, threshold="5min").equals(expected)
+        assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="5min"), expected)
         assert hfp(x, sf_hypno=1, threshold="5min").size == 0
 
         # 1c. Equal length
@@ -91,7 +92,7 @@ class TestHypno(unittest.TestCase):
             'values': [0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 0],
             'start': [0, 2, 4, 6, 8, 11, 14, 16, 18, 20, 22, 25],
             'length': [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]})
-        assert hfp(x, sf_hypno=1 / 60, threshold="2min", equal_length=True).equals(expected)
+        assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="2min", equal_length=True), expected)
 
         # TEST 2: MULTI-CLASS VECTOR
         x = [0, 0, 0, 0, 1, 2, 2, 2, 2, 2, 2, 0, 0, 0, 1, 0, 1]
@@ -101,4 +102,4 @@ class TestHypno(unittest.TestCase):
             'start': [0, 4, 5, 11, 14, 15, 16],
             'length': [4, 1, 6, 3, 1, 1, 1]})
 
-        assert hfp(x, sf_hypno=1 / 60, threshold="0min").equals(expected)
+        assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="0min"), expected)

--- a/yasa/tests/test_hypno.py
+++ b/yasa/tests/test_hypno.py
@@ -77,13 +77,14 @@ class TestHypno(unittest.TestCase):
         expected = pd.DataFrame({
             'values': [0, 1, 0, 1, 0],
             'start': [0, 11, 14, 16, 25],
-            'length': [11, 3, 2, 9, 2]})
+            'length': [11, 3, 2, 9, 2]}, dtype=np.int32)
 
         assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="0min"), expected)
         assert_frame_equal(hfp(x, sf_hypno=1, threshold="0min"), expected)
 
         # 1b. With thresholding
-        expected = pd.DataFrame({'values': [0, 1], 'start': [0, 16], 'length': [11, 9]})
+        expected = pd.DataFrame(
+            {'values': [0, 1], 'start': [0, 16], 'length': [11, 9]}, dtype=np.int32)
         assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="5min"), expected)
         assert hfp(x, sf_hypno=1, threshold="5min").size == 0
 
@@ -91,7 +92,7 @@ class TestHypno(unittest.TestCase):
         expected = pd.DataFrame({
             'values': [0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 0],
             'start': [0, 2, 4, 6, 8, 11, 14, 16, 18, 20, 22, 25],
-            'length': [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]})
+            'length': [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]}, dtype=np.int32)
         assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="2min", equal_length=True), expected)
 
         # TEST 2: MULTI-CLASS VECTOR
@@ -100,6 +101,5 @@ class TestHypno(unittest.TestCase):
         expected = pd.DataFrame({
             'values': [0, 1, 2, 0, 1, 0, 1],
             'start': [0, 4, 5, 11, 14, 15, 16],
-            'length': [4, 1, 6, 3, 1, 1, 1]})
-
+            'length': [4, 1, 6, 3, 1, 1, 1]}, dtype=np.int32)
         assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="0min"), expected)

--- a/yasa/tests/test_hypno.py
+++ b/yasa/tests/test_hypno.py
@@ -25,6 +25,7 @@ def create_raw(npts, ch_names=['F4-M1', 'F3-M2'], sf=100):
 
 
 class TestHypno(unittest.TestCase):
+    """Test functions in the hypno.py file."""
 
     def test_conversion(self):
         """Test str <--> int conversion.
@@ -107,3 +108,8 @@ class TestHypno(unittest.TestCase):
             'start': [0, 4, 5, 11, 14, 15, 16],
             'length': [4, 1, 6, 3, 1, 1, 1]})
         assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="0min"), expected, **kwargs)
+
+        # With a string dtype
+        expected["values"] = expected["values"].astype(str)
+        assert_frame_equal(
+            hfp(np.array(x).astype(str), sf_hypno=1 / 60, threshold="0min"), expected, **kwargs)

--- a/yasa/tests/test_hypno.py
+++ b/yasa/tests/test_hypno.py
@@ -77,23 +77,27 @@ class TestHypno(unittest.TestCase):
         expected = pd.DataFrame({
             'values': [0, 1, 0, 1, 0],
             'start': [0, 11, 14, 16, 25],
-            'length': [11, 3, 2, 9, 2]}, dtype=np.int64)
+            'length': [11, 3, 2, 9, 2]})
 
-        assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="0min"), expected)
-        assert_frame_equal(hfp(x, sf_hypno=1, threshold="0min"), expected)
+        kwargs = dict(
+            check_dtype=False, check_index_type=False, check_column_type=False,
+            check_frame_type=False)
+        assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="0min"), expected, **kwargs)
+        assert_frame_equal(hfp(x, sf_hypno=1, threshold="0min"), expected, **kwargs)
 
         # 1b. With thresholding
         expected = pd.DataFrame(
-            {'values': [0, 1], 'start': [0, 16], 'length': [11, 9]}, dtype=np.int64)
-        assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="5min"), expected)
+            {'values': [0, 1], 'start': [0, 16], 'length': [11, 9]})
+        assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="5min"), expected, **kwargs)
         assert hfp(x, sf_hypno=1, threshold="5min").size == 0
 
         # 1c. Equal length
         expected = pd.DataFrame({
             'values': [0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 0],
             'start': [0, 2, 4, 6, 8, 11, 14, 16, 18, 20, 22, 25],
-            'length': [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]}, dtype=np.int64)
-        assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="2min", equal_length=True), expected)
+            'length': [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]})
+        assert_frame_equal(
+            hfp(x, sf_hypno=1 / 60, threshold="2min", equal_length=True), expected, **kwargs)
 
         # TEST 2: MULTI-CLASS VECTOR
         x = [0, 0, 0, 0, 1, 2, 2, 2, 2, 2, 2, 0, 0, 0, 1, 0, 1]
@@ -101,5 +105,5 @@ class TestHypno(unittest.TestCase):
         expected = pd.DataFrame({
             'values': [0, 1, 2, 0, 1, 0, 1],
             'start': [0, 4, 5, 11, 14, 15, 16],
-            'length': [4, 1, 6, 3, 1, 1, 1]}, dtype=np.int64)
-        assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="0min"), expected)
+            'length': [4, 1, 6, 3, 1, 1, 1]})
+        assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="0min"), expected, **kwargs)

--- a/yasa/tests/test_hypno.py
+++ b/yasa/tests/test_hypno.py
@@ -77,14 +77,14 @@ class TestHypno(unittest.TestCase):
         expected = pd.DataFrame({
             'values': [0, 1, 0, 1, 0],
             'start': [0, 11, 14, 16, 25],
-            'length': [11, 3, 2, 9, 2]}, dtype=np.int32)
+            'length': [11, 3, 2, 9, 2]}, dtype=np.int64)
 
         assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="0min"), expected)
         assert_frame_equal(hfp(x, sf_hypno=1, threshold="0min"), expected)
 
         # 1b. With thresholding
         expected = pd.DataFrame(
-            {'values': [0, 1], 'start': [0, 16], 'length': [11, 9]}, dtype=np.int32)
+            {'values': [0, 1], 'start': [0, 16], 'length': [11, 9]}, dtype=np.int64)
         assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="5min"), expected)
         assert hfp(x, sf_hypno=1, threshold="5min").size == 0
 
@@ -92,7 +92,7 @@ class TestHypno(unittest.TestCase):
         expected = pd.DataFrame({
             'values': [0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 0],
             'start': [0, 2, 4, 6, 8, 11, 14, 16, 18, 20, 22, 25],
-            'length': [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]}, dtype=np.int32)
+            'length': [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]}, dtype=np.int64)
         assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="2min", equal_length=True), expected)
 
         # TEST 2: MULTI-CLASS VECTOR
@@ -101,5 +101,5 @@ class TestHypno(unittest.TestCase):
         expected = pd.DataFrame({
             'values': [0, 1, 2, 0, 1, 0, 1],
             'start': [0, 4, 5, 11, 14, 15, 16],
-            'length': [4, 1, 6, 3, 1, 1, 1]}, dtype=np.int32)
+            'length': [4, 1, 6, 3, 1, 1, 1]}, dtype=np.int64)
         assert_frame_equal(hfp(x, sf_hypno=1 / 60, threshold="0min"), expected)

--- a/yasa/tests/test_io.py
+++ b/yasa/tests/test_io.py
@@ -2,7 +2,7 @@
 import pytest
 import logging
 import unittest
-from yasa.io import (set_log_level, is_tensorpac_installed,
+from yasa.io import (is_sleepecg_installed, set_log_level, is_tensorpac_installed,
                      is_pyriemann_installed)
 
 logger = logging.getLogger('yasa')
@@ -33,3 +33,4 @@ class TestIO(unittest.TestCase):
         """Test dependancies."""
         is_tensorpac_installed()
         is_pyriemann_installed()
+        is_sleepecg_installed()


### PR DESCRIPTION
Hi,

This PR adds two new functions to YASA, which will hopefully be released in YASA 0.6.2.

- [x] The yasa.hypno_find_periods is a flexible function that allows to find sequences of consecutive values exceeding a certain duration in hypnogram. See the "Examples" section of the documentation of the function for some concrete examples.
- [x]  The yasa.hrv_stage is the first function of the new "Heart rate analysis" module. Specifically, it allows to calculate heart rate and heart rate variability (HRV) features from an ECG. By default, the cardiac features are calculated for each period of N2, N3 or REM sleep that are longer than 2 minutes. It uses the yasa.hypno_find_periods to find the periods (and thus inherits from the flexibility of that function), and the [SleepECG](https://sleepecg.readthedocs.io/en/stable/) library to detect the heartbeats in the ECG. It also returns, for each epoch, the indices of the detected heartbeats. This can be used to calculate more advanced heart rate variability metrics (e.g. frequency domain), or do some EEG-ECG coupling analysis.

I am looking for 1-2 reviewers to review this PR. (Suggestions @olmurillo @remrama, who else?)

Thanks!
