### PR TITLE
Use MNE for conversion Volts to uV

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -92,13 +92,11 @@ Finally, the underlying data can be accessed with:
 
 .. code-block:: python
 
-  >>> data = raw.get_data() * 1e6
+  >>> data = raw.get_data(units="uV")
   >>> print(data.shape)
   (19, 2892000)
 
 In this example, ``data`` is a two-dimensional NumPy array where the rows represent the channels (19 EEG channels) and the columns represent the data samples (~3 million samples per channel).
-
-Note that we have also multiplied the data by a million (=1e6). This is because MNE converts the data from microVolts (the standard EEG unit) to Volts when loading the EDF file. We therefore revert this operation, i.e. convert from Volts to microVolts.
 
 Hypnogram
 ~~~~~~~~~

--- a/notebooks/02_spindles_detection_multi.ipynb
+++ b/notebooks/02_spindles_detection_multi.ipynb
@@ -16,7 +16,7 @@
     "- The data must be a numpy array of shape *(n_channels, n_samples)*.\n",
     "- The sampling frequency `sf` must be the same for all channels.\n",
     "- A list of the channel names (`ch_names`) must be provided as well.\n",
-    "- The unit of the data must be $\\mu V$. Note that the default unit in [MNE](https://martinos.org/mne/dev/generated/mne.io.Raw.html) is $V$. Therefore, if you use MNE, you must multiply your data by 1e6 (1 $V$ = 1,000,000 $\\mu V$).\n",
+    "- The unit of the data must be $\\mu V$.\n",
     "\n",
     "## Example 1: Using a NumPy array\n",
     "\n",

--- a/notebooks/06_sw_detection_multi.ipynb
+++ b/notebooks/06_sw_detection_multi.ipynb
@@ -16,7 +16,7 @@
     "- The data must be a numpy array of shape *(n_channels, n_samples)*.\n",
     "- The sampling frequency `sf` must be the same for all channels.\n",
     "- A list of the channel names (`ch_names`) must be provided as well.\n",
-    "- The unit of the data must be $\\mu V$. Note that the default unit in [MNE](https://martinos.org/mne/dev/generated/mne.io.Raw.html) is $V$. Therefore, if you use MNE, you must multiply your data by 1e6 (1 $V$ = 1,000,000 $\\mu V$).\n",
+    "- The unit of the data must be $\\mu V$.\n",
     "\n",
     "## Example 1: Using NumPy\n",
     "\n",

--- a/notebooks/08_bandpower.ipynb
+++ b/notebooks/08_bandpower.ipynb
@@ -66,7 +66,7 @@
     "raw.filter(0.5, 45)\n",
     "\n",
     "# Extract the data and convert from V to uV\n",
-    "data = raw._data * 1e6\n",
+    "data = raw.get_data(units=\"uV\")\n",
     "sf = raw.info['sfreq']\n",
     "chan = raw.ch_names\n",
     "\n",
@@ -2166,7 +2166,7 @@
    ],
    "source": [
     "# Create a 3-D array\n",
-    "data = raw.get_data() * 1e6\n",
+    "data = raw.get_data(units=\"uV\")\n",
     "sf = raw.info['sfreq']\n",
     "\n",
     "_, data = yasa.sliding_window(data, sf, window=30)\n",

--- a/notebooks/08_bandpower.ipynb
+++ b/notebooks/08_bandpower.ipynb
@@ -35,9 +35,7 @@
     "\n",
     "### EEG data\n",
     "\n",
-    "Let's load ~45 min of mid-afternoon nap data (6 channels), sampled at 100 Hz. We use the [MNE library](https://mne.tools/stable/index.html), which includes various functions and utilities for reading EEG data and electrode locations. For a description of all the file formats supported by MNE, please refer to https://mne.tools/stable/auto_tutorials/io/plot_20_reading_eeg_data.html\n",
-    "\n",
-    "Note that during loading, MNE automatically scale the EEG data from microVolts (uV) to Volts. However, YASA requires the data to be in microVolts (uV), and therefore we need to reverse this scaling by multiplying our data by 1e6 (1 V = 1,000,000 uV)."
+    "Let's load ~45 min of mid-afternoon nap data (6 channels), sampled at 100 Hz. We use the [MNE library](https://mne.tools/stable/index.html), which includes various functions and utilities for reading EEG data and electrode locations. For a description of all the file formats supported by MNE, please refer to https://mne.tools/stable/auto_tutorials/io/plot_20_reading_eeg_data.html"
    ]
   },
   {

--- a/notebooks/09_IRASA.ipynb
+++ b/notebooks/09_IRASA.ipynb
@@ -59,7 +59,7 @@
     "raw = mne.io.read_raw_fif('data_resting_EO_200Hz_raw.fif', preload=True, verbose=0)\n",
     "\n",
     "# Extract data, sf, and chan\n",
-    "data = raw.get_data() * 1e6  # Convert data from V to uV\n",
+    "data = raw.get_data(units=\"uV\")\n",
     "sf = raw.info['sfreq']\n",
     "chan = raw.ch_names\n",
     "\n",
@@ -171,7 +171,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "20-Feb-22 14:19:23 | WARNING | The evaluated frequency range ends after the resampled Nyquist frequency (52.63Hz). Decrease the upper band (30.00Hz) or decrease the maximum value of the hset (1.90).\n"
+      "02-Jun-22 14:35:06 | WARNING | The evaluated frequency range ends after the resampled Nyquist frequency (52.63Hz). Decrease the upper band (30.00Hz) or decrease the maximum value of the hset (1.90).\n"
      ]
     }
    ],
@@ -275,7 +275,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "20-Feb-22 14:19:24 | WARNING | The evaluated frequency range ends after the resampled Nyquist frequency (52.63Hz). Decrease the upper band (30.00Hz) or decrease the maximum value of the hset (1.90).\n"
+      "02-Jun-22 14:35:07 | WARNING | The evaluated frequency range ends after the resampled Nyquist frequency (52.63Hz). Decrease the upper band (30.00Hz) or decrease the maximum value of the hset (1.90).\n"
      ]
     },
     {

--- a/notebooks/09_IRASA.ipynb
+++ b/notebooks/09_IRASA.ipynb
@@ -33,9 +33,7 @@
    "source": [
     "## Data loading\n",
     "\n",
-    "Let's load 6 min of eyes open EEG data, sampled at 200 Hz. We use the [MNE library](https://mne.tools/stable/index.html), which includes various functions and utilities for reading EEG data and electrode locations. For a description of all the file formats supported by MNE, please refer to https://mne.tools/stable/auto_tutorials/io/plot_20_reading_eeg_data.html\n",
-    "\n",
-    "Note that during loading, MNE automatically scale the EEG data from microVolts (uV) to Volts. However, YASA requires the data to be in microVolts (uV), and therefore we need to reverse this scaling by multiplying our data by 1e6 (1 V = 1,000,000 uV)."
+    "Let's load 6 min of eyes open EEG data, sampled at 200 Hz. We use the [MNE library](https://mne.tools/stable/index.html), which includes various functions and utilities for reading EEG data and electrode locations. For a description of all the file formats supported by MNE, please refer to https://mne.tools/stable/auto_tutorials/io/plot_20_reading_eeg_data.html"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.16.5
 scipy
 pandas
-mne>=0.20
+mne>=0.23
 numba
 outdated
 matplotlib

--- a/yasa/detection.py
+++ b/yasa/detection.py
@@ -40,7 +40,7 @@ def _check_data_hypno(data, sf=None, ch_names=None, hypno=None, include=None, ch
     if isinstance(data, mne.io.BaseRaw):
         sf = data.info['sfreq']  # Extract sampling frequency
         ch_names = data.ch_names  # Extract channel names
-        data = data.get_data(units="uV")
+        data = data.get_data(units=dict(eeg="uV", emg="uV", eog="uV", ecg="uV"))
     else:
         assert sf is not None, 'sf must be specified if not using MNE Raw.'
     data = np.asarray(data, dtype=np.float64)

--- a/yasa/detection.py
+++ b/yasa/detection.py
@@ -40,7 +40,7 @@ def _check_data_hypno(data, sf=None, ch_names=None, hypno=None, include=None, ch
     if isinstance(data, mne.io.BaseRaw):
         sf = data.info['sfreq']  # Extract sampling frequency
         ch_names = data.ch_names  # Extract channel names
-        data = data.get_data() * 1e6  # Convert from V to uV
+        data = data.get_data(units="uV")
     else:
         assert sf is not None, 'sf must be specified if not using MNE Raw.'
     data = np.asarray(data, dtype=np.float64)
@@ -1858,10 +1858,9 @@ def rem_detect(loc, roc, sf, hypno=None, include=4, amplitude=(50, 325), duratio
         .. warning::
             The default unit of :py:class:`mne.io.BaseRaw` is Volts.
             Therefore, if passing data from a :py:class:`mne.io.BaseRaw`,
-            you need to multiply the data by 1e6 to convert to micro-Volts
-            (1 V = 1,000,000 uV), e.g.:
+            make sure to use units="uV" to get the data in micro-Volts, e.g.:
 
-            >>> data = raw.get_data() * 1e6  # Make sure that data is in uV
+            >>> data = raw.get_data(units="uV")  # Make sure that data is in uV
     sf : float
         Sampling frequency of the data, in Hz.
     hypno : array_like

--- a/yasa/features.py
+++ b/yasa/features.py
@@ -158,7 +158,7 @@ def compute_features_stage(raw, hypno, max_freq=35, spindles_params=dict(),
     raw_eeg.filter(l_freq, h_freq, verbose=False)
 
     # Extract data and sf
-    data = raw_eeg.get_data() * 1e6  # Scale from Volts (MNE default) to uV
+    data = raw_eeg.get_data(units="uV")  # Scale from Volts (MNE default) to uV
     sf = raw_eeg.info['sfreq']
     assert data.ndim == 2, 'data must be 2D (chan, times).'
     assert hypno.size == data.shape[1], 'Hypno must have same size as data.'

--- a/yasa/features.py
+++ b/yasa/features.py
@@ -158,7 +158,7 @@ def compute_features_stage(raw, hypno, max_freq=35, spindles_params=dict(),
     raw_eeg.filter(l_freq, h_freq, verbose=False)
 
     # Extract data and sf
-    data = raw_eeg.get_data(units="uV")  # Scale from Volts (MNE default) to uV
+    data = raw_eeg.get_data(units=dict(eeg="uV", emg="uV", eog="uV", ecg="uV"))
     sf = raw_eeg.info['sfreq']
     assert data.ndim == 2, 'data must be 2D (chan, times).'
     assert hypno.size == data.shape[1], 'Hypno must have same size as data.'

--- a/yasa/spectral.py
+++ b/yasa/spectral.py
@@ -96,7 +96,7 @@ def bandpower(data, sf=None, ch_names=None, hypno=None, include=(2, 3),
     if isinstance(data, mne.io.BaseRaw):
         sf = data.info['sfreq']  # Extract sampling frequency
         ch_names = data.ch_names  # Extract channel names
-        data = data.get_data() * 1e6  # Convert from V to uV
+        data = data.get_data(units="uV")  # Convert from V to uV
         _, npts = data.shape
     else:
         # Safety checks
@@ -447,7 +447,7 @@ def irasa(data, sf=None, ch_names=None, band=(1, 30),
         ch_names = data.ch_names  # Extract channel names
         hp = data.info['highpass']  # Extract highpass filter
         lp = data.info['lowpass']  # Extract lowpass filter
-        data = data.get_data() * 1e6  # Convert from V to uV
+        data = data.get_data(units="uV")  # Convert from V to uV
     else:
         # Safety checks
         assert isinstance(data, np.ndarray), 'Data must be a numpy array.'

--- a/yasa/spectral.py
+++ b/yasa/spectral.py
@@ -96,7 +96,7 @@ def bandpower(data, sf=None, ch_names=None, hypno=None, include=(2, 3),
     if isinstance(data, mne.io.BaseRaw):
         sf = data.info['sfreq']  # Extract sampling frequency
         ch_names = data.ch_names  # Extract channel names
-        data = data.get_data(units="uV")  # Convert from V to uV
+        data = data.get_data(units=dict(eeg="uV", emg="uV", eog="uV", ecg="uV"))
         _, npts = data.shape
     else:
         # Safety checks
@@ -447,7 +447,7 @@ def irasa(data, sf=None, ch_names=None, band=(1, 30),
         ch_names = data.ch_names  # Extract channel names
         hp = data.info['highpass']  # Extract highpass filter
         lp = data.info['lowpass']  # Extract lowpass filter
-        data = data.get_data(units="uV")  # Convert from V to uV
+        data = data.get_data(units=dict(eeg="uV", emg="uV", eog="uV", ecg="uV"))
     else:
         # Safety checks
         assert isinstance(data, np.ndarray), 'Data must be a numpy array.'

--- a/yasa/staging.py
+++ b/yasa/staging.py
@@ -197,7 +197,7 @@ class SleepStaging:
             sf = raw_pick.info['sfreq']
 
         # Get data and convert to microVolts
-        data = raw_pick.get_data() * 1e6
+        data = raw_pick.get_data(units="uV")
 
         # Extract duration of recording in minutes
         duration_minutes = data.shape[1] / sf / 60

--- a/yasa/staging.py
+++ b/yasa/staging.py
@@ -197,7 +197,7 @@ class SleepStaging:
             sf = raw_pick.info['sfreq']
 
         # Get data and convert to microVolts
-        data = raw_pick.get_data(units="uV")
+        data = raw_pick.get_data(units=dict(eeg="uV", emg="uV", eog="uV", ecg="uV"))
 
         # Extract duration of recording in minutes
         duration_minutes = data.shape[1] / sf / 60

--- a/yasa/tests/test_spectral.py
+++ b/yasa/tests/test_spectral.py
@@ -34,7 +34,7 @@ hypno_mne = hypno_upsample_to_data(hypno=hypno_mne, sf_hypno=(1 / 30),
 # Eyes-open 6 minutes resting-state, 2 channels, 200 Hz
 raw_eo = mne.io.read_raw_fif('notebooks/data_resting_EO_200Hz_raw.fif',
                              verbose=0)
-data_eo = raw_eo.get_data(units="uV")
+data_eo = raw_eo.get_data(units=dict(eeg="uV", emg="uV", eog="uV", ecg="uV"))
 sf_eo = raw_eo.info['sfreq']
 chan_eo = raw_eo.ch_names
 

--- a/yasa/tests/test_spectral.py
+++ b/yasa/tests/test_spectral.py
@@ -34,7 +34,7 @@ hypno_mne = hypno_upsample_to_data(hypno=hypno_mne, sf_hypno=(1 / 30),
 # Eyes-open 6 minutes resting-state, 2 channels, 200 Hz
 raw_eo = mne.io.read_raw_fif('notebooks/data_resting_EO_200Hz_raw.fif',
                              verbose=0)
-data_eo = raw_eo.get_data() * 1e6
+data_eo = raw_eo.get_data(units="uV")
 sf_eo = raw_eo.info['sfreq']
 chan_eo = raw_eo.ch_names
 


### PR DESCRIPTION
Closes https://github.com/raphaelvallat/yasa/issues/59

MNE automatically scales EEG (and EOG, EMG, ECG data) to Volts. YASA however expect the data to be in micro-Volts. The current behavior of YASA is to manually scale the data by 1e6 to convert from Volts to uV:

```python
data = raw.get_data() * 1e6
```

With this PR, the conversion is now performed directly within the [mne.Raw.get_data() ](https://mne.tools/stable/generated/mne.io.Raw.html?highlight=pick_types#mne.io.Raw.get_data)function, using the `units` argument (added in MNE 0.23.0):

```python
data = raw.get_data(units=dict(eeg="uV", emg="uV", eog="uV", ecg="uV"))
```

This converts the EEG, EMG, EOG and ECG data to uV, while leaving the other channel types in their original MNE units.

Can someone please review this PR before June 20, 2022?

PS: I'll update the changelog once https://github.com/raphaelvallat/yasa/pull/68 is merged.

Thank you,
Raphael