### PR TITLE
Added lightgbm to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ INSTALL_REQUIRES = [
     "lspopt",
     "ipywidgets",
     "joblib",
+    "lightgbm",
 ]
 
 PACKAGES = [

--- a/yasa/staging.py
+++ b/yasa/staging.py
@@ -23,7 +23,7 @@ class SleepStaging:
     """
     Automatic sleep staging of polysomnography data.
 
-    To run the automatic sleep staging, you must install the
+    The automatic sleep staging requires the
     `LightGBM <https://lightgbm.readthedocs.io/>`_ and
     `antropy <https://github.com/raphaelvallat/antropy>`_ packages.
 


### PR DESCRIPTION
This should resolve #96 by simply adding `lightgbm` to the `setup.py` file. I tested with a local re-install and the automatic sleep staging worked without any additional install of `lightgbm`.

In the original issue, I suggested the `SleepStaging` doc should reference the pip (or conda) installable versions of `lightgbm`. But now that it comes installed with YASA, I don't think that's necessary anymore. However, now that the user doesn't _need_ to install neither `antropy` nor `lightgbm` manually, I find that doc wording a bit misleading in a different way. It's worded as the user should be installing them manually ("To run the automatic sleep staging, you must install..."). Is the point just to acknowledge their use?

Assuming you want that note kept in, I reworded it slightly to just say that the automatic staging _uses_ them rather than asking the user to install them. But if it's all the same to you I would just take that whole comment out. It's confusing to me because the algorithm requires a lot of other packages too. And since the user doesn't need to install anything else it doesn't feel pertinent. But either is cool with me!