### PR TITLE
Solves obscure numba bug with just replacing range -> zip

### DIFF
--- a/yasa/numba.py
+++ b/yasa/numba.py
@@ -18,9 +18,9 @@ def _corr(x, y):
     n = x.size
     mx, my = x.mean(), y.mean()
     xm2s, ym2s, r_num = 0, 0, 0
-    for i in range(n):
-        xm = x[i] - mx
-        ym = y[i] - my
+    for xi, yi in zip(x, y):
+        xm = xi - mx
+        ym = yi - my
         r_num += xm * ym
         xm2s += xm**2
         ym2s += ym**2


### PR DESCRIPTION
Solves an obscure numba bug (specifically in `yasa.numba._corr`) that was popping up for only some users/systems. See the madness in #107.

Note: I thought it would be best to add some new tests for this, but I looked and the current tests in `test_numba.py` _do_ catch it. So it's really just specific to some systems that don't get run during the unittests.