### PR TITLE
Hotfix for MNE plot_topomap deprecation

### DIFF
--- a/yasa/plotting.py
+++ b/yasa/plotting.py
@@ -461,10 +461,12 @@ def topoplot(
     with sns.axes_style("white"):
         fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
 
-        # vmin and vmax have been deprecated in MNE v1.3
+        # vmin, vmax and show_names have been deprecated in MNE v1.3
         mne_version = float(mne.__version__[:3])
 
         if mne_version >= 1.3:
+            if "show_names" not in kwargs:
+                kwargs.pop("show_names")
             im, _ = mne.viz.plot_topomap(
                 data=data.iloc[:, 0][chan],
                 pos=Info,
@@ -476,10 +478,8 @@ def topoplot(
                 **kwargs,
             )
         else:
-
             if "show_names" not in kwargs:
                 kwargs["show_names"] = True
-
             im, _ = mne.viz.plot_topomap(
                 data=data.iloc[:, 0][chan],
                 pos=Info,

--- a/yasa/plotting.py
+++ b/yasa/plotting.py
@@ -462,17 +462,33 @@ def topoplot(
     # Start the plot
     with sns.axes_style("white"):
         fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
-        im, _ = mne.viz.plot_topomap(
-            data=data.iloc[:, 0][chan],
-            pos=Info,
-            vmin=vmin,
-            vmax=vmax,
-            mask=data.iloc[:, 1][chan],
-            cmap=cmap,
-            show=False,
-            axes=ax,
-            **kwargs,
-        )
+
+        # vmin and vmax have been deprecated in MNE v1.3
+        mne_version = float(mne.__version__[:3])
+
+        if mne_version >= 1.3:
+            im, _ = mne.viz.plot_topomap(
+                data=data.iloc[:, 0][chan],
+                pos=Info,
+                vlim=(vmin, vmax),
+                mask=data.iloc[:, 1][chan],
+                cmap=cmap,
+                show=False,
+                axes=ax,
+                **kwargs,
+            )
+        else:
+            im, _ = mne.viz.plot_topomap(
+                data=data.iloc[:, 0][chan],
+                pos=Info,
+                vmin=vmin,
+                vmax=vmax,
+                mask=data.iloc[:, 1][chan],
+                cmap=cmap,
+                show=False,
+                axes=ax,
+                **kwargs,
+            )
 
         if title is not None:
             ax.set_title(title)

--- a/yasa/plotting.py
+++ b/yasa/plotting.py
@@ -450,8 +450,6 @@ def topoplot(
         kwargs["res"] = 256
     if "names" not in kwargs:
         kwargs["names"] = chan
-    if "show_names" not in kwargs:
-        kwargs["show_names"] = True
     if "mask_params" not in kwargs:
         kwargs["mask_params"] = dict(marker=None)
 
@@ -478,6 +476,10 @@ def topoplot(
                 **kwargs,
             )
         else:
+
+            if "show_names" not in kwargs:
+                kwargs["show_names"] = True
+
             im, _ = mne.viz.plot_topomap(
                 data=data.iloc[:, 0][chan],
                 pos=Info,

--- a/yasa/plotting.py
+++ b/yasa/plotting.py
@@ -465,7 +465,7 @@ def topoplot(
         mne_version = float(mne.__version__[:3])
 
         if mne_version >= 1.3:
-            if "show_names" not in kwargs:
+            if "show_names" in kwargs:
                 kwargs.pop("show_names")
             im, _ = mne.viz.plot_topomap(
                 data=data.iloc[:, 0][chan],


### PR DESCRIPTION
Avoid `TypeError: plot_topomap() got an unexpected keyword argument 'vmin'` in MNE v1.3