### PR TITLE
Update simulate_hypno to return Hypnogram instance

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,11 @@ which comes with several pre-built functions (named methods) and attributes. See
 
 Please see the documentation of :py:class:`yasa.Hypnogram` for more details.
 
+.. important::
+  The adoption of object-oriented :py:class:`yasa.Hypnogram` usage brings along critical changes to several YASA function, for example:
+
+  * :py:func:`yasa.simulate_hypno` now returns a `yasa.Hypnogram` instead of a :py:class:`np.ndarray`.
+
 ----------------------------------------------------------------------------------------
 
 v0.6.3 (December 2022)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -38,7 +38,7 @@ Please see the documentation of :py:class:`yasa.Hypnogram` for more details.
 .. important::
   The adoption of object-oriented :py:class:`yasa.Hypnogram` usage brings along critical changes to several YASA function, for example:
 
-  * :py:func:`yasa.simulate_hypno` now returns a `yasa.Hypnogram` instead of a :py:class:`np.ndarray`.
+  * :py:func:`yasa.simulate_hypno` now returns a `yasa.Hypnogram` instead of a :py:class:`numpy.ndarray`.
 
 ----------------------------------------------------------------------------------------
 

--- a/yasa/hypno.py
+++ b/yasa/hypno.py
@@ -284,6 +284,7 @@ class Hypnogram:
     def tib(self):
         """Time in bed, or total duration of the hypnogram, expressed in minutes."""
         return self._tib
+        ## Q: Should this be called "duration" instead?
 
     @property
     def n_stages(self):
@@ -1720,10 +1721,6 @@ def simulate_hypno(
     # Create YASA hypnogram instance
     if trans_probas.attrs.get("default") and n_stages < 5:
         # Reduce stages when trans_probas is a hypnogram with higher n_stages than desired output
-        ## Q: Should yasa.Hypnogram accept mismatched n_stages & values
-        ##    and then apply the .consolidate_stages method automatically
-        ##    with a logger warning?
-        ##    That would make something like this unnecessary.
         hyp = Hypnogram(values_str, n_stages=5, freq=freq, **kwargs)
         hyp = hyp.consolidate_stages(n_stages)
     else:

--- a/yasa/hypno.py
+++ b/yasa/hypno.py
@@ -626,7 +626,7 @@ class Hypnogram:
         10      WAKE     SLEEP
         11      WAKE      WAKE
         """
-        kwargs_ = {
+        simulate_hypno_kwargs = {
             "tib": self.duration,
             "n_stages": self.n_stages,
             "freq": self.freq,
@@ -634,12 +634,13 @@ class Hypnogram:
             "start": self.start,
             "scorer": self.scorer,
         }
-        if (n_stages := kwargs.pop("n_stages", None)) is not None:
-            assert n_stages <= self.n_stages, "new n_stages must be <= original n_stages"
-        kwargs_.update(kwargs)
-        hyp = simulate_hypno(**kwargs_)
-        if n_stages is not None and n_stages < self.n_stages:
-            hyp = hyp.consolidate_stages(n_stages)
+        new_n_stages = kwargs.pop("n_stages", None)
+        if new_n_stages is not None:
+            assert new_n_stages <= self.n_stages, "new n_stages must be <= original n_stages"
+        simulate_hypno_kwargs.update(kwargs)
+        hyp = simulate_hypno(**simulate_hypno_kwargs)
+        if new_n_stages is not None and new_n_stages < self.n_stages:
+            hyp = hyp.consolidate_stages(new_n_stages)
         return hyp
 
     def sleep_statistics(self):

--- a/yasa/hypno.py
+++ b/yasa/hypno.py
@@ -1584,6 +1584,7 @@ def simulate_hypno(
     7      N2
     8      N2
     9      N2
+    Name: Stage, dtype: object
 
     >>> hyp = simulate_hypno(tib=5, n_stages=2, seed=1)
     >>> print(hyp)
@@ -1598,6 +1599,24 @@ def simulate_hypno(
     7      N2
     8      N2
     9      N2
+    Name: Stage, dtype: object
+
+    Add some Unscored epochs.
+    >>> hyp = simulate_hypno(tib=5, n_stages=2, seed=1)
+    >>> hyp.hypno.iloc[-2:] = "UNS"
+    >>> print(hyp)
+    Epoch
+    0     WAKE
+    1    SLEEP
+    2    SLEEP
+    3    SLEEP
+    4    SLEEP
+    5    SLEEP
+    6    SLEEP
+    7    SLEEP
+    8      UNS
+    9      UNS
+    Name: Stage, dtype: object
 
     Base the data off a real subject's transition matrix.
 

--- a/yasa/hypno.py
+++ b/yasa/hypno.py
@@ -1649,9 +1649,9 @@ def simulate_hypno(
     # Validate input
     assert isinstance(tib, (int, float)) and tib > 0, "tib must be a number > 0"
     assert isinstance(n_stages, int) and (2 <= n_stages <= 5), "n_stages must be 2, 3, 4, or 5"
-    assert isinstance(freq, str) and pd.Timedelta(freq) <= pd.Timedelta("30s"), (
-        "freq must be a pandas frequency string and <= 30 seconds"
-    )
+    assert isinstance(freq, str) and pd.Timedelta(freq) <= pd.Timedelta(
+        "30s"
+    ), "freq must be a pandas frequency string and <= 30 seconds"
     if seed is not None:
         assert isinstance(seed, int) and seed >= 0, "seed must be an integer >= 0"
     if trans_probas is not None:
@@ -1703,9 +1703,9 @@ def simulate_hypno(
         assert init_probas is not None, "trans_probas must include 'WAKE' in the index"
 
     stage_order = init_probas.index.tolist()
-    assert stage_order == trans_probas.index.tolist() == trans_probas.columns.tolist(), (
-        "init_probas and trans_probas must all have matching indices"
-    )
+    assert (
+        stage_order == trans_probas.index.tolist() == trans_probas.columns.tolist()
+    ), "init_probas and trans_probas must all have matching indices"
 
     # Extract probabilities as arrays
     trans_arr = trans_probas.to_numpy()
@@ -1722,7 +1722,7 @@ def simulate_hypno(
     # Generate hypnogram integer values
     values_int = _markov_sequence(init_arr, trans_arr, n_epochs)
     # Convert to hypnogram string values (based on indices)
-    values_str = [ stage_order[x] for x in values_int ]
+    values_str = [stage_order[x] for x in values_int]
 
     # Create YASA hypnogram instance
     if trans_probas.attrs.get("default"):

--- a/yasa/hypno.py
+++ b/yasa/hypno.py
@@ -1732,8 +1732,8 @@ def simulate_hypno(
     # Generate hypnogram
     values_int = _markov_sequence(init_arr, trans_arr, n_epochs)
     values_str = hypno_int_to_str(values_int)
-    hypno = Hypnogram(values_str, freq=freq, **kwargs)
+    hyp = Hypnogram(values_str, freq=freq, **kwargs)
     if n_stages < 5:
-        hypno = hypno.consolidate_stages(n_stages)
+        hyp = hyp.consolidate_stages(n_stages)
 
-    return hypno
+    return hyp

--- a/yasa/tests/test_hypno.py
+++ b/yasa/tests/test_hypno.py
@@ -143,9 +143,7 @@ class TestHypno(unittest.TestCase):
         )
 
         # Handling different frequencies
-        np.testing.assert_array_equal(
-            hyp.hypno, simulate_hypno(tib=4, freq="0.5min", seed=1).hypno
-        )
+        np.testing.assert_array_equal(hyp.hypno, simulate_hypno(tib=4, freq="0.5min", seed=1).hypno)
         np.testing.assert_array_equal(
             hyp.upsample("5s").hypno, simulate_hypno(tib=4, freq="5s", seed=1).hypno
         )

--- a/yasa/tests/test_hypno.py
+++ b/yasa/tests/test_hypno.py
@@ -166,13 +166,14 @@ class TestHypno(unittest.TestCase):
         trans_probas.loc[:, :] = np.eye(5, 5)
         assert not simulate_hypno(trans_probas=trans_probas).as_int().any()
 
-        # When trans_probas has fewer stages than allowed by n_stages
-        trans_probas = trans_probas.drop("REM", axis=0).drop("REM", axis=1)
-        trans_probas.loc[:, :] = np.full((4, 4), 0.25)
-        simulate_hypno(trans_probas=trans_probas)
         # When trans_proba has more stages than allowed by n_stages
         with pytest.raises(AssertionError):
-            simulate_hypno(n_stages=2, trans_probas=trans_probas)
+            simulate_hypno(n_stages=4, trans_probas=trans_probas)
+
+        # When trans_probas includes only a subset of stages allowed by n_stages
+        trans_probas = trans_probas.drop(index="REM", columns="REM")
+        trans_probas.loc[:, :] = np.full((4, 4), 0.25)
+        simulate_hypno(trans_probas=trans_probas)
 
         # Passing **kwargs through to yasa.Hypnogram
         shyp = simulate_hypno(tib=5, scorer="RV", start="2022-12-15 22:30:00")

--- a/yasa/tests/test_hypno.py
+++ b/yasa/tests/test_hypno.py
@@ -148,8 +148,8 @@ class TestHypno(unittest.TestCase):
             hyp.upsample("5s").hypno, simulate_hypno(tib=4, freq="5s", seed=1).hypno
         )
         assert simulate_hypno(tib=4, freq="15s").n_epochs == 16
-        assert simulate_hypno(tib=4, freq="15s").tib == 4
-        assert simulate_hypno(tib=4, freq="30s").tib == 4
+        assert simulate_hypno(tib=4, freq="15s").duration == 4
+        assert simulate_hypno(tib=4, freq="30s").duration == 4
         with pytest.raises(AssertionError):
             simulate_hypno(freq="60s")
 

--- a/yasa/tests/test_hypno.py
+++ b/yasa/tests/test_hypno.py
@@ -138,8 +138,7 @@ class TestHypno(unittest.TestCase):
         assert simulate_hypno(tib=500, n_stages=2).hypno.nunique() == 2
         assert simulate_hypno(tib=500, n_stages=3).hypno.nunique() == 3
         assert np.array_equal(
-            simulate_hypno(tib=4, seed=1).as_int(),
-            np.array([0, 1, 1, 2, 2, 2, 2, 2]),
+            simulate_hypno(tib=4, seed=1).as_int(), np.array([0, 1, 1, 2, 2, 2, 2, 2])
         )
 
         # Passing in probabilities
@@ -148,20 +147,20 @@ class TestHypno(unittest.TestCase):
             index=["WAKE", "N1", "N2", "N3", "REM"],
             columns=["WAKE", "N1", "N2", "N3", "REM"],
         )
-        simulate_hypno(trans_probas=trans_probas)
-        simulate_hypno(init_probas=trans_probas.loc["WAKE"])
+        simulate_hypno(tib=2, trans_probas=trans_probas)
+        simulate_hypno(tib=2, init_probas=trans_probas.loc["WAKE"])
+        simulate_hypno(tib=2, trans_probas=trans_probas, init_probas=trans_probas.loc["WAKE"])
         # Setting all probabilities between stages as zero
         trans_probas.loc[:, :] = np.eye(5, 5)
         assert not simulate_hypno(trans_probas=trans_probas).as_int().any()
 
-        # Test conflicts between n_stages and trans_proba
-        # When trans_proba has fewer stages than allowed by n_stages
+        # When trans_probas has fewer stages than allowed by n_stages
         trans_probas = trans_probas.drop("REM", axis=0).drop("REM", axis=1)
         trans_probas.loc[:, :] = np.full((4, 4), 0.25)
         simulate_hypno(trans_probas=trans_probas)
         # When trans_proba has more stages than allowed by n_stages
         with pytest.raises(AssertionError):
-            simulate_hypno(tib=10, n_stages=2, trans_probas=trans_probas)
+            simulate_hypno(n_stages=2, trans_probas=trans_probas)
 
         # Pass **kwargs through to yasa.Hypnogram
         shyp = simulate_hypno(tib=5, scorer="RV", start="2022-12-15 22:30:00")

--- a/yasa/tests/test_hypnoclass.py
+++ b/yasa/tests/test_hypnoclass.py
@@ -64,8 +64,6 @@ class TestHypnoClass(unittest.TestCase):
         hyp.transition_matrix()
         hyp.find_periods()
         hyp.as_annotations()
-        hyp.simulate_similar(tib=10, scorer="YASA")
-        assert hyp.simulate_similar().n_epochs == hyp.n_epochs
         sstats = hyp.sleep_statistics()
         truth = {
             "TIB": 60.0,
@@ -80,6 +78,24 @@ class TestHypnoClass(unittest.TestCase):
             "WAKE": 10.5,
         }
         assert sstats == truth
+        shyp = hyp.simulate_similar()
+        assert shyp.sampling_frequency == hyp.sampling_frequency
+        assert shyp.hypno.index.name == hyp.hypno.index.name
+        assert shyp.timedelta == hyp.timedelta
+        assert shyp.n_epochs == hyp.n_epochs
+        assert shyp.n_stages == hyp.n_stages
+        assert shyp.scorer == hyp.scorer
+        assert shyp.labels == hyp.labels
+        assert shyp.start == hyp.start
+        assert shyp.freq == hyp.freq
+        assert shyp.tib == hyp.tib
+        assert hyp.simulate_similar(tib=2, scorer="YASA").scorer == "YASA"
+        assert hyp.simulate_similar(tib=2).n_epochs == 4
+        assert hyp.simulate_similar(freq="30min").n_epochs == 4
+        # np.testing.assert_array_equal(
+        #     simulate_hypno(freq="10min", seed=42).simulate_similar(n_stages=3).as_int(),
+        #     [x, x, x, x, x, x, x, x, x, x],
+        # )
 
         # Invert the mapping
         hyp.mapping = {"SLEEP": 0, "WAKE": 1}

--- a/yasa/tests/test_hypnoclass.py
+++ b/yasa/tests/test_hypnoclass.py
@@ -78,24 +78,7 @@ class TestHypnoClass(unittest.TestCase):
             "WAKE": 10.5,
         }
         assert sstats == truth
-        shyp = hyp.simulate_similar()
-        assert shyp.sampling_frequency == hyp.sampling_frequency
-        assert shyp.hypno.index.name == hyp.hypno.index.name
-        assert shyp.timedelta == hyp.timedelta
-        assert shyp.n_epochs == hyp.n_epochs
-        assert shyp.n_stages == hyp.n_stages
-        assert shyp.scorer == hyp.scorer
-        assert shyp.labels == hyp.labels
-        assert shyp.start == hyp.start
-        assert shyp.freq == hyp.freq
-        assert shyp.tib == hyp.tib
-        assert hyp.simulate_similar(tib=2, scorer="YASA").scorer == "YASA"
-        assert hyp.simulate_similar(tib=2).n_epochs == 4
-        assert hyp.simulate_similar(freq="30min").n_epochs == 4
-        # np.testing.assert_array_equal(
-        #     simulate_hypno(freq="10min", seed=42).simulate_similar(n_stages=3).as_int(),
-        #     [x, x, x, x, x, x, x, x, x, x],
-        # )
+        assert sstats["TIB"] == hyp.tib
 
         # Invert the mapping
         hyp.mapping = {"SLEEP": 0, "WAKE": 1}
@@ -118,6 +101,26 @@ class TestHypnoClass(unittest.TestCase):
         assert hyp_up.size == npts
         assert hyp_up.dtype == int
         hyp_up = hyp.upsample_to_data(raw.get_data(), sf=100)
+
+        # yasa.Hypnogram.simulate_similar
+        shyp = hyp.simulate_similar()
+        assert shyp.tib == hyp.tib
+        assert shyp.freq == hyp.freq
+        assert shyp.start == hyp.start
+        assert shyp.scorer == hyp.scorer
+        assert shyp.labels == hyp.labels
+        assert shyp.n_epochs == hyp.n_epochs
+        assert shyp.n_stages == hyp.n_stages
+        assert shyp.hypno.index.name == hyp.hypno.index.name
+        assert shyp.sampling_frequency == hyp.sampling_frequency
+        assert hyp.simulate_similar(tib=2, scorer="YASA").scorer == "YASA"
+        assert hyp.simulate_similar(tib=2, start="2022-11-10").start == "2022-11-10"
+        assert hyp.simulate_similar(tib=2, freq="30s").n_epochs == 4
+        assert hyp.simulate_similar(tib=2, freq="15s").n_epochs == 8
+        np.testing.assert_array_equal(
+            simulate_hypno(seed=1).simulate_similar(tib=2, n_stages=4, freq="10s", seed=6).as_int(),
+            [0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2],
+        )
 
     def test_3stages_hypno(self):
         """Test 3-stages Hypnogram class"""

--- a/yasa/tests/test_hypnoclass.py
+++ b/yasa/tests/test_hypnoclass.py
@@ -115,11 +115,9 @@ class TestHypnoClass(unittest.TestCase):
         assert shyp.sampling_frequency == hyp.sampling_frequency
         assert hyp.simulate_similar(tib=2, scorer="YASA").scorer == "YASA"
         assert hyp.simulate_similar(tib=2, start="2022-11-10").start == "2022-11-10"
-        assert hyp.simulate_similar(tib=2, freq="30s").n_epochs == 4
-        assert hyp.simulate_similar(tib=2, freq="15s").n_epochs == 8
         np.testing.assert_array_equal(
-            simulate_hypno(seed=1).simulate_similar(tib=2, n_stages=4, freq="10s", seed=6).as_int(),
-            [0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2],
+            simulate_hypno(seed=1).simulate_similar(tib=5, seed=6).as_int(),
+            [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
         )
 
     def test_3stages_hypno(self):

--- a/yasa/tests/test_hypnoclass.py
+++ b/yasa/tests/test_hypnoclass.py
@@ -3,7 +3,7 @@ import mne
 import unittest
 import numpy as np
 import pandas as pd
-from yasa.hypno import simulate_hypno, Hypnogram
+from yasa.hypno import simulate_hypno, Hypnogram, hypno_str_to_int
 
 
 def create_raw(npts, ch_names=["F4-M1", "F3-M2"], sf=100):
@@ -20,19 +20,18 @@ class TestHypnoClass(unittest.TestCase):
 
     def test_2stages_hypno(self):
         """Test 2-stages Hypnogram class"""
-        values_int = simulate_hypno(tib=120, n_stages=2, seed=42)
-        values = pd.Series(values_int).map({0: "W", 1: "S"}).to_numpy()
-        hyp = Hypnogram(values, n_stages=2)
+        hyp = simulate_hypno(tib=120, n_stages=2, seed=42)
         print(hyp)
         print(str(hyp))
 
         # Check properties
-        np.testing.assert_array_equal(hyp.hypno.str.get(0).to_numpy(), values)
+        np.testing.assert_array_equal(hyp.hypno.str.get(0).unique(), ["W", "S"])
         assert isinstance(hyp.hypno.index, pd.RangeIndex)
         assert hyp.hypno.index.name == "Epoch"
         assert hyp.sampling_frequency == 1 / 30
         assert hyp.freq == "30s"
-        assert hyp.n_epochs == len(values)
+        assert hyp.n_epochs == 240
+        assert hyp.tib == 120
         assert hyp.n_stages == 2
         assert hyp.labels == ["SLEEP", "WAKE", "ART", "UNS"]
         assert hyp.mapping == {"WAKE": 0, "SLEEP": 1, "ART": -1, "UNS": -2}
@@ -42,6 +41,7 @@ class TestHypnoClass(unittest.TestCase):
         assert hyp.timedelta[-1] == pd.Timedelta("0 days 01:59:30")
 
         # Adding start time
+        values = hyp.hypno.to_numpy()
         hyp = Hypnogram(values, n_stages=2, start="2022-11-10 13:30:10", freq="15s", scorer="Test")
         assert isinstance(hyp.hypno.index, pd.DatetimeIndex)
         assert hyp.hypno.index.name == "Time"
@@ -51,6 +51,7 @@ class TestHypnoClass(unittest.TestCase):
         assert hyp.freq == "15s"
         assert hyp.start == "2022-11-10 13:30:10"
         assert hyp.n_epochs == len(values)
+        assert hyp.tib == 60
         assert hyp.timedelta[0] == pd.Timedelta("0 days 00:00:00")
         assert hyp.timedelta[-1] == pd.Timedelta("0 days 00:59:45")
         assert hyp.hypno.index[-1] == hyp.hypno.index[0] + pd.Timedelta(
@@ -58,22 +59,25 @@ class TestHypnoClass(unittest.TestCase):
         )
 
         # Test class methods
+        values_int = hypno_str_to_int(hyp.hypno.tolist(), mapping_dict={"wake": 0, "sleep": 1})
         np.testing.assert_array_equal(hyp.as_int(), values_int)
         hyp.transition_matrix()
         hyp.find_periods()
         hyp.as_annotations()
+        hyp.simulate_similar(tib=10, scorer="YASA")
+        assert hyp.simulate_similar().n_epochs == hyp.n_epochs
         sstats = hyp.sleep_statistics()
         truth = {
             "TIB": 60.0,
             "SPT": 58.75,
-            "WASO": 9.25,
-            "TST": 49.5,
-            "SE": 82.5,
-            "SME": 84.2553,
-            "SFI": 0.303,
+            "WASO": 6.0,
+            "TST": 52.75,
+            "SE": 87.9167,
+            "SME": 89.7872,
+            "SFI": 0.2844,
             "SOL": 1.25,
             "SOL_5min": 1.25,
-            "WAKE": 10.5,
+            "WAKE": 7.25,
         }
         assert sstats == truth
 
@@ -101,9 +105,7 @@ class TestHypnoClass(unittest.TestCase):
 
     def test_3stages_hypno(self):
         """Test 3-stages Hypnogram class"""
-        values = simulate_hypno(tib=120, sf=1, n_stages=3, seed=42)
-        values = pd.Series(values).map({0: "W", 2: "NREM", 4: "REM"}).to_numpy()
-        hyp = Hypnogram(values, n_stages=3, freq="1s")
+        hyp = simulate_hypno(tib=120, n_stages=3, freq="1s", seed=42)
         assert hyp.sampling_frequency == 1
         assert hyp.freq == "1s"
         assert hyp.n_stages == 3
@@ -116,9 +118,7 @@ class TestHypnoClass(unittest.TestCase):
 
     def test_4stages_hypno(self):
         """Test 4-stages Hypnogram class"""
-        values = simulate_hypno(tib=400, n_stages=4, seed=42)
-        values = pd.Series(values).map({0: "W", 2: "Light", 3: "Deep", 4: "REM"}).to_numpy()
-        hyp = Hypnogram(values, n_stages=4, freq="30s")
+        hyp = simulate_hypno(tib=400, n_stages=4, freq="30s", seed=42)
         assert hyp.n_stages == 4
         assert hyp.labels == ["WAKE", "LIGHT", "DEEP", "REM", "ART", "UNS"]
         assert hyp.mapping == {"WAKE": 0, "LIGHT": 2, "DEEP": 3, "REM": 4, "ART": -1, "UNS": -2}
@@ -130,9 +130,7 @@ class TestHypnoClass(unittest.TestCase):
 
     def test_5stages_hypno(self):
         """Test 5-stages Hypnogram class"""
-        values = simulate_hypno(tib=600, n_stages=5, seed=42)
-        values = pd.Series(values).map({0: "W", 1: "N1", 2: "N2", 3: "N3", 4: "REM"}).to_numpy()
-        hyp = Hypnogram(values, n_stages=5, freq="30s")
+        hyp = simulate_hypno(tib=600, n_stages=5, freq="30s", seed=42)
         assert hyp.n_stages == 5
         assert hyp.labels == ["WAKE", "N1", "N2", "N3", "REM", "ART", "UNS"]
         assert hyp.mapping == {

--- a/yasa/tests/test_hypnoclass.py
+++ b/yasa/tests/test_hypnoclass.py
@@ -31,7 +31,7 @@ class TestHypnoClass(unittest.TestCase):
         assert hyp.sampling_frequency == 1 / 30
         assert hyp.freq == "30s"
         assert hyp.n_epochs == 240
-        assert hyp.tib == 120
+        assert hyp.duration == 120
         assert hyp.n_stages == 2
         assert hyp.labels == ["SLEEP", "WAKE", "ART", "UNS"]
         assert hyp.mapping == {"WAKE": 0, "SLEEP": 1, "ART": -1, "UNS": -2}
@@ -51,7 +51,7 @@ class TestHypnoClass(unittest.TestCase):
         assert hyp.freq == "15s"
         assert hyp.start == "2022-11-10 13:30:10"
         assert hyp.n_epochs == len(values)
-        assert hyp.tib == 60
+        assert hyp.duration == 60
         assert hyp.timedelta[0] == pd.Timedelta("0 days 00:00:00")
         assert hyp.timedelta[-1] == pd.Timedelta("0 days 00:59:45")
         assert hyp.hypno.index[-1] == hyp.hypno.index[0] + pd.Timedelta(
@@ -78,7 +78,7 @@ class TestHypnoClass(unittest.TestCase):
             "WAKE": 10.5,
         }
         assert sstats == truth
-        assert sstats["TIB"] == hyp.tib
+        assert sstats["TIB"] == hyp.duration
 
         # Invert the mapping
         hyp.mapping = {"SLEEP": 0, "WAKE": 1}
@@ -104,11 +104,11 @@ class TestHypnoClass(unittest.TestCase):
 
         # yasa.Hypnogram.simulate_similar
         shyp = hyp.simulate_similar()
-        assert shyp.tib == hyp.tib
         assert shyp.freq == hyp.freq
         assert shyp.start == hyp.start
         assert shyp.scorer == hyp.scorer
         assert shyp.labels == hyp.labels
+        assert shyp.duration == hyp.duration
         assert shyp.n_epochs == hyp.n_epochs
         assert shyp.n_stages == hyp.n_stages
         assert shyp.hypno.index.name == hyp.hypno.index.name

--- a/yasa/tests/test_hypnoclass.py
+++ b/yasa/tests/test_hypnoclass.py
@@ -25,7 +25,7 @@ class TestHypnoClass(unittest.TestCase):
         print(str(hyp))
 
         # Check properties
-        np.testing.assert_array_equal(hyp.hypno.str.get(0).unique(), ["W", "S"])
+        np.testing.assert_array_equal(hyp.hypno.str.get(0)[:10], np.repeat(["W", "S"], 5))
         assert isinstance(hyp.hypno.index, pd.RangeIndex)
         assert hyp.hypno.index.name == "Epoch"
         assert hyp.sampling_frequency == 1 / 30
@@ -70,14 +70,14 @@ class TestHypnoClass(unittest.TestCase):
         truth = {
             "TIB": 60.0,
             "SPT": 58.75,
-            "WASO": 6.0,
-            "TST": 52.75,
-            "SE": 87.9167,
-            "SME": 89.7872,
-            "SFI": 0.2844,
+            "WASO": 9.25,
+            "TST": 49.5,
+            "SE": 82.5,
+            "SME": 84.2553,
+            "SFI": 0.303,
             "SOL": 1.25,
             "SOL_5min": 1.25,
-            "WAKE": 7.25,
+            "WAKE": 10.5,
         }
         assert sstats == truth
 


### PR DESCRIPTION
Brings `yasa.simulate_hypno` up to speed with the new object-oriented `yasa.Hypnogram` (see Issue #120).

I wasn't sure about how to handle the changelog since I think we're expecting other function changes, so feel free to suggest a different approach to documenting this.

@raphaelvallat care to review?