### PR TITLE
Hypnogram plot_hypnogram method

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -39,6 +39,7 @@ Please see the documentation of :py:class:`yasa.Hypnogram` for more details.
   The adoption of object-oriented :py:class:`yasa.Hypnogram` usage brings along critical changes to several YASA function, for example:
 
   * :py:func:`yasa.simulate_hypno` now returns a `yasa.Hypnogram` instead of a :py:class:`numpy.ndarray`.
+  * The suggested approach to plotting hypnograms is through the :py:meth:`yasa.Hypnogram.plot_hypnogram` method. The old function :py:func:`yasa.plot_hypnogram` still exists, but now *requires* a `yasa.Hypnogram` instance as input.
 
 ----------------------------------------------------------------------------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -38,8 +38,8 @@ Please see the documentation of :py:class:`yasa.Hypnogram` for more details.
 .. important::
   The adoption of object-oriented :py:class:`yasa.Hypnogram` usage brings along critical changes to several YASA function, for example:
 
-  * :py:func:`yasa.simulate_hypno` now returns a `yasa.Hypnogram` instead of a :py:class:`numpy.ndarray`.
-  * The suggested approach to plotting hypnograms is through the :py:meth:`yasa.Hypnogram.plot_hypnogram` method. The old function :py:func:`yasa.plot_hypnogram` still exists, but now *requires* a `yasa.Hypnogram` instance as input.
+  * :py:func:`yasa.simulate_hypno` now returns a :py:class:`yasa.Hypnogram` instead of a :py:class:`numpy.ndarray`.
+  * The suggested approach to plotting hypnograms is through the :py:meth:`yasa.Hypnogram.plot_hypnogram` method. The old function :py:func:`yasa.plot_hypnogram` still exists, but now *requires* a :py:class:`yasa.Hypnogram` instance as input.
 
 ----------------------------------------------------------------------------------------
 

--- a/yasa/hypno.py
+++ b/yasa/hypno.py
@@ -328,6 +328,16 @@ class Hypnogram:
 
     # CLASS METHODS BELOW
 
+    def copy(self):
+        """Return a new copy of the current Hypnogram."""
+        return type(self)(
+            values=self.hypno.to_numpy(),
+            n_stages=self.n_stages,
+            freq=self.freq,
+            start=self.start,
+            scorer=self.scorer,
+        )
+
     def as_annotations(self):
         """
         Return a pandas DataFrame summarizing epoch-level information.

--- a/yasa/hypno.py
+++ b/yasa/hypno.py
@@ -602,7 +602,7 @@ class Hypnogram:
         .. plot::
 
             >>> from yasa import simulate_hypnogram
-            >>> ax = simulate_hypnogram(tib=480, seed=88).plot_hypnogram()
+            >>> ax = simulate_hypno(tib=480, seed=88).plot_hypnogram(highlight="REM"")
         """
         return plot_hypnogram(self, **kwargs)
 
@@ -1638,22 +1638,19 @@ def simulate_hypno(
 
     .. plot::
 
-        >>> import matplotlib.pyplot as plt
         >>> import numpy as np
-        >>> import yasa
+        >>> import matplotlib.pyplot as plt
+        >>> from yasa import Hypnogram, hypno_int_to_str
         >>> url = (
         >>>     "https://github.com/raphaelvallat/yasa/raw/master/"
         >>>     "notebooks/data_full_6hrs_100Hz_hypno_30s.txt"
         >>> )
-        >>> values_int = np.loadtxt(url)
-        >>> values_str = yasa.hypno_int_to_str(values_int)
-        >>> hyp = yasa.Hypnogram(values_str)
-        >>> shyp = hyp.simulate_similar(seed=2)
-        >>> fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(9, 6))
-        >>> yasa.plot_hypnogram(hyp.as_int(), ax=ax1)
-        >>> yasa.plot_hypnogram(shyp.as_int(), ax=ax2)
-        >>> ax1.set_title("True hypnogram")
-        >>> ax2.set_title("Simulated hypnogram")
+        >>> values_str = hypno_int_to_str(np.loadtxt(url))
+        >>> real_hyp = Hypnogram(values_str)
+        >>> fake_hyp = real_hyp.simulate_similar(seed=2)
+        >>> fig, (ax1, ax2) = plt.subplots(nrows=2, figsize=(7, 5))
+        >>> real_hyp.plot_hypnogram(ax=ax1).set_title("Real hypnogram")
+        >>> fake_hyp.plot_hypnogram(ax=ax2).set_title("Fake hypnogram")
         >>> plt.tight_layout()
     """
     # Extract yasa.Hypnogram defaults, which will be assumed later but need throughout

--- a/yasa/hypno.py
+++ b/yasa/hypno.py
@@ -6,6 +6,7 @@ import logging
 import numpy as np
 import pandas as pd
 from yasa.io import set_log_level
+from yasa.plotting import plot_hypnogram
 from yasa.sleepstats import transition_matrix
 
 __all__ = [
@@ -193,7 +194,7 @@ class Hypnogram:
             scorer, (type(None), str, int)
         ), "`scorer` must be either None, or a string or an integer."
         if n_stages == 2:
-            accepted = ["S", "W", "SLEEP", "WAKE", "ART", "UNS"]
+            accepted = ["W", "WAKE", "S", "SLEEP", "ART", "UNS"]
             mapping = {"WAKE": 0, "SLEEP": 1, "ART": -1, "UNS": -2}
         elif n_stages == 3:
             accepted = ["WAKE", "W", "NREM", "REM", "R", "ART", "UNS"]
@@ -581,10 +582,29 @@ class Hypnogram:
             self.hypno, self.sampling_frequency, threshold=threshold, equal_length=equal_length
         )
 
-    def plot_hypnogram(self):
-        """Plot the hypnogram."""
-        # TODO: Add support for 2, 3 and 4-stages hypnogram
-        raise NotImplementedError
+    def plot_hypnogram(self, **kwargs):
+        """Plot the hypnogram.
+
+        .. seealso:: :py:func:`yasa.plot_hypnogram`
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Optional keyword arguments passed to :py:func:`yasa.plot_hypnogram`.
+
+        Returns
+        -------
+        ax : :py:class:`matplotlib.axes.Axes`
+            Matplotlib Axes
+
+        Examples
+        --------
+        .. plot::
+
+            >>> from yasa import simulate_hypnogram
+            >>> ax = simulate_hypnogram(tib=480, seed=88).plot_hypnogram()
+        """
+        return plot_hypnogram(self, **kwargs)
 
     def simulate_similar(self, **kwargs):
         """Simulate a new hypnogram based on properties of the current hypnogram.

--- a/yasa/plotting.py
+++ b/yasa/plotting.py
@@ -111,7 +111,7 @@ def plot_hypnogram(hyp, lw=1, fill_color=None, highlight=None, ax=None):
     # Draw background filling
     if fill_color is not None:
         bline = hyp.mapping["WAKE"]  # len(stage_order) - 1 to fill from bottom
-        ax.stairs(yvalues.clip(baseline), bins, baseline=bline, color=fill_color, fill=True, lw=0)
+        ax.stairs(yvalues.clip(bline), bins, baseline=bline, color=fill_color, fill=True, lw=0)
     # Draw main hypnogram line, highlighted stage line, and Artefact/Unscored line
     ax.stairs(yvalues, bins, baseline=None, color="black", lw=lw)
     if not yvals_highlight.mask.all():

--- a/yasa/plotting.py
+++ b/yasa/plotting.py
@@ -108,10 +108,8 @@ def plot_hypnogram(hyp, lw=1.5, highlight="REM", fill_color=None, ax=None):
         bins /= 60 if hyp.duration <= 90 else 3600
         xlabel = "Time [mins]" if hyp.duration <= 90 else "Time [hrs]"
 
-    # Make masks to draw with different colors
-    yvals_art_uns = np.ma.masked_greater(yvalues, -1)
-    highlight_int = hyp.mapping[highlight] if highlight in hyp.mapping else np.nan
-    yvals_highlight = np.ma.masked_not_equal(yvalues, highlight_int)
+    # Make mask to draw the highlighted stage
+    yvals_highlight = np.ma.masked_not_equal(yvalues, hyp.mapping.get(highlight))
 
     # Open the figure
     if ax is None:
@@ -125,8 +123,6 @@ def plot_hypnogram(hyp, lw=1.5, highlight="REM", fill_color=None, ax=None):
     ax.stairs(yvalues, bins, baseline=None, color="black", lw=lw)
     if not yvals_highlight.mask.all():
         ax.hlines(yvals_highlight, xmin=bins[:-1], xmax=bins[1:], color="red", lw=lw)
-    if not yvals_art_uns.mask.all():
-        ax.hlines(yvals_art_uns, xmin=bins[:-1], xmax=bins[1:], color="grey", lw=lw)
 
     # Aesthetics
     ax.use_sticky_edges = False

--- a/yasa/plotting.py
+++ b/yasa/plotting.py
@@ -13,7 +13,7 @@ from matplotlib.colors import Normalize, ListedColormap
 __all__ = ["plot_hypnogram", "plot_spectrogram", "topoplot"]
 
 
-def plot_hypnogram(hyp, lw=1, fill_color=None, highlight=None, ax=None):
+def plot_hypnogram(hyp, lw=1.5, highlight="REM", fill_color=None, ax=None):
     """
     Plot a hypnogram.
 
@@ -25,10 +25,10 @@ def plot_hypnogram(hyp, lw=1, fill_color=None, highlight=None, ax=None):
         A YASA hypnogram instance.
     lw : float
         Linewidth.
-    fill_color : str
-        Optional color to fill space above hypnogram line.
-    highlight : str
+    highlight : str or None
         Optional stage to highlight with alternate color.
+    fill_color : str or None
+        Optional color to fill space above hypnogram line.
     ax : :py:class:`matplotlib.axes.Axes`
         Axis on which to draw the plot, optional.
 
@@ -41,21 +41,27 @@ def plot_hypnogram(hyp, lw=1, fill_color=None, highlight=None, ax=None):
     --------
     .. plot::
 
-        >>> from yasa import Hypnogram
+        >>> from yasa import simulate_hypno
         >>> import matplotlib.pyplot as plt
-        >>> values = 4 * ["W", "N1", "N2", "N3", "REM"] + ["ART", "N2", "REM", "W", "UNS"]
-        >>> hyp = Hypnogram(values, freq="24min").upsample("30s")
-        >>> ax = hyp.plot_hypnogram(lw=2, highlight="REM", fill_color="thistle")
+        >>> hyp = simulate_hypno(tib=300, seed=11)
+        >>> ax = hyp.plot_hypnogram()
         >>> plt.tight_layout()
 
     .. plot::
 
-        >>> from yasa import simulate_hypno
+        >>> from yasa import Hypnogram
+        >>> values = 4 * ["W", "N1", "N2", "N3", "REM"] + ["ART", "N2", "REM", "W", "UNS"]
+        >>> hyp = Hypnogram(values, freq="24min").upsample("30s")
+        >>> ax = hyp.plot_hypnogram(lw=2, fill_color="thistle")
+        >>> plt.tight_layout()
+
+    .. plot::
+
         >>> fig, axes = plt.subplots(nrows=2, figsize=(6, 4), constrained_layout=True)
-        >>> hyp_a = simulate_hypno(tib=90, n_stages=3, seed=99)
-        >>> hyp_b = simulate_hypno(tib=90, n_stages=3, seed=99, start="2022-01-31 23:30:00")
-        >>> hyp_a.plot_hypnogram(fill_color="whitesmoke", ax=axes[0])
-        >>> hyp_b.plot_hypnogram(fill_color="whitesmoke", ax=axes[1])
+        >>> hyp_a = simulate_hypno(n_stages=3, seed=99)
+        >>> hyp_b = simulate_hypno(n_stages=3, seed=99, start="2022-01-31 23:30:00")
+        >>> hyp_a.plot_hypnogram(lw=1, fill_color="whitesmoke", highlight=None, ax=axes[0])
+        >>> hyp_b.plot_hypnogram(lw=1, fill_color="whitesmoke", highlight=None, ax=axes[1])
     """
     from yasa.hypno import Hypnogram  # Avoiding circular import
 

--- a/yasa/plotting.py
+++ b/yasa/plotting.py
@@ -67,6 +67,9 @@ def plot_hypnogram(hyp, lw=1.5, highlight="REM", fill_color=None, ax=None):
 
     assert isinstance(hyp, Hypnogram), "`hypno` must be YASA Hypnogram."
 
+    # Work with a copy of the Hypnogram to not alter the original
+    hyp = hyp.copy()
+
     # Increase font size while preserving original
     old_fontsize = plt.rcParams["font.size"]
     plt.rcParams.update({"font.size": 18})

--- a/yasa/plotting.py
+++ b/yasa/plotting.py
@@ -236,29 +236,29 @@ def plot_spectrogram(
     plt.rcParams.update({"font.size": 18})
 
     # Safety checks
-    assert isinstance(data, np.ndarray), "Data must be a 1D NumPy array."
-    assert isinstance(sf, (int, float)), "sf must be int or float."
-    assert data.ndim == 1, "Data must be a 1D (single-channel) NumPy array."
-    assert isinstance(win_sec, (int, float)), "win_sec must be int or float."
-    assert isinstance(fmin, (int, float)), "fmin must be int or float."
-    assert isinstance(fmax, (int, float)), "fmax must be int or float."
-    assert fmin < fmax, "fmin must be strictly inferior to fmax."
-    assert fmax < sf / 2, "fmax must be less than Nyquist (sf / 2)."
-    assert isinstance(vmin, (int, float, type(None))), "vmin must be int, float, or None."
-    assert isinstance(vmax, (int, float, type(None))), "vmax must be int, float, or None."
+    assert isinstance(data, np.ndarray), "`data` must be a 1D NumPy array."
+    assert isinstance(sf, (int, float)), "`sf` must be int or float."
+    assert data.ndim == 1, "`data` must be a 1D (single-channel) NumPy array."
+    assert isinstance(win_sec, (int, float)), "`win_sec` must be int or float."
+    assert isinstance(fmin, (int, float)), "`fmin` must be int or float."
+    assert isinstance(fmax, (int, float)), "`fmax` must be int or float."
+    assert fmin < fmax, "`fmin` must be strictly inferior to `fmax`."
+    assert fmax < sf / 2, "`fmax` must be less than Nyquist (sf / 2)."
+    assert isinstance(vmin, (int, float, type(None))), "`vmin` must be int, float, or None."
+    assert isinstance(vmax, (int, float, type(None))), "`vmax` must be int, float, or None."
     if vmin is not None:
-        assert isinstance(vmax, (int, float)), "vmax must be int or float if vmin is provided"
+        assert isinstance(vmax, (int, float)), "`vmax` must be int or float if `vmin` is provided."
     if vmax is not None:
-        assert isinstance(vmin, (int, float)), "vmin must be int or float if vmax is provided"
+        assert isinstance(vmin, (int, float)), "`vmin` must be int or float if `vmax` is provided."
     if hyp is not None:
-        # Validate and handle hypnogram-related inputs
-        from yasa.hypno import Hypnogram
+        from yasa.hypno import Hypnogram  # Avoiding circular import
+
         assert isinstance(hyp, Hypnogram)
-        assert hyp.n_epochs == data.size, "Hypno must have the same number of samples as data."
+        assert hyp.n_epochs == data.size, "`hyp` must have the same number of samples as data."
 
     # Calculate multi-taper spectrogram
     nperseg = int(win_sec * sf)
-    assert data.size > 2 * nperseg, "Data length must be at least 2 * win_sec."
+    assert data.size > 2 * nperseg, "`data` length must be at least 2 * `win_sec`."
     f, t, Sxx = spectrogram_lspopt(data, sf, nperseg=nperseg, noverlap=0)
     Sxx = 10 * np.log10(Sxx)  # Convert uV^2 / Hz --> dB / Hz
 
@@ -402,13 +402,13 @@ def topoplot(
     plt.rcParams.update({"savefig.transparent": "True"})
 
     # Make sure we don't do any in-place modification
-    assert isinstance(data, pd.Series), "Data must be a Pandas Series"
+    assert isinstance(data, pd.Series), "`data` must be a Pandas Series"
     data = data.copy()
 
     # Add mask, if present
     if mask is not None:
-        assert isinstance(mask, pd.Series), "mask must be a Pandas Series"
-        assert mask.dtype.kind in "bi", "mask must be True/False or 0/1."
+        assert isinstance(mask, pd.Series), "`mask` must be a Pandas Series"
+        assert mask.dtype.kind in "bi", "`mask` must be True/False or 0/1."
     else:
         mask = pd.Series(1, index=data.index, name="mask")
 

--- a/yasa/plotting.py
+++ b/yasa/plotting.py
@@ -58,6 +58,7 @@ def plot_hypnogram(hyp, lw=1, fill_color=None, highlight=None, ax=None):
         >>> hyp_b.plot_hypnogram(fill_color="whitesmoke", ax=axes[1])
     """
     from yasa import Hypnogram  # Avoiding circular import
+
     assert isinstance(hyp, Hypnogram), "`hypno` must be YASA Hypnogram."
 
     # Increase font size while preserving original
@@ -79,7 +80,7 @@ def plot_hypnogram(hyp, lw=1, fill_color=None, highlight=None, ax=None):
     if hyp.n_stages == 5:
         stage_order.insert(stage_order.index("WAKE") + 1, stage_order.pop(stage_order.index("REM")))
     # Reset the Hypnogram mapping so any future returns have this order
-    hyp.mapping = { stage: i for i, stage in enumerate(stage_order) }
+    hyp.mapping = {stage: i for i, stage in enumerate(stage_order)}
 
     ## Extract values to plot ##
     hypno = hyp.as_int()
@@ -95,7 +96,7 @@ def plot_hypnogram(hyp, lw=1, fill_color=None, highlight=None, ax=None):
     else:
         final_bin_edge = hyp.duration * 60
         bins = np.append(hyp.timedelta[hypno.index].total_seconds(), final_bin_edge)
-        bins /= (60 if hyp.duration <= 90 else 3600)
+        bins /= 60 if hyp.duration <= 90 else 3600
         xlabel = "Time [mins]" if hyp.duration <= 90 else "Time [hrs]"
 
     # Make masks to draw with different colors
@@ -109,8 +110,8 @@ def plot_hypnogram(hyp, lw=1, fill_color=None, highlight=None, ax=None):
 
     # Draw background filling
     if fill_color is not None:
-        baseline = hyp.mapping["WAKE"]  # len(stage_order) - 1 to fill from bottom
-        ax.stairs(yvalues.clip(baseline), bins, baseline=baseline, fill=True, color=fill_color, lw=0)
+        bline = hyp.mapping["WAKE"]  # len(stage_order) - 1 to fill from bottom
+        ax.stairs(yvalues.clip(baseline), bins, baseline=bline, color=fill_color, fill=True, lw=0)
     # Draw main hypnogram line, highlighted stage line, and Artefact/Unscored line
     ax.stairs(yvalues, bins, baseline=None, color="black", lw=lw)
     if not yvals_highlight.mask.all():

--- a/yasa/tests/test_hypnoclass.py
+++ b/yasa/tests/test_hypnoclass.py
@@ -80,6 +80,10 @@ class TestHypnoClass(unittest.TestCase):
         }
         assert sstats == truth
         assert sstats["TIB"] == hyp.duration
+        hyp_cp = hyp.copy()
+        np.testing.assert_array_equal(hyp_cp.as_int(), hyp.as_int())
+        assert hyp_cp.sleep_statistics() == truth
+        assert hyp_cp.scorer == hyp.scorer
 
         # Invert the mapping
         hyp.mapping = {"SLEEP": 0, "WAKE": 1}

--- a/yasa/tests/test_hypnoclass.py
+++ b/yasa/tests/test_hypnoclass.py
@@ -3,6 +3,7 @@ import mne
 import unittest
 import numpy as np
 import pandas as pd
+import matplotlib.pyplot as plt
 from yasa.hypno import simulate_hypno, Hypnogram, hypno_str_to_int
 
 
@@ -119,6 +120,11 @@ class TestHypnoClass(unittest.TestCase):
             simulate_hypno(seed=1).simulate_similar(tib=5, seed=6).as_int(),
             [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
         )
+
+        # yasa.Hypnogram.plot_hypnogram
+        assert isinstance(hyp.plot_hypnogram(), plt.Axes)
+        hyp.plot_hypnogram(fill_color="cornflowerblue", highlight="N3", lw=0.5)
+        plt.close("all")
 
     def test_3stages_hypno(self):
         """Test 3-stages Hypnogram class"""

--- a/yasa/tests/test_hypnoclass.py
+++ b/yasa/tests/test_hypnoclass.py
@@ -130,7 +130,7 @@ class TestHypnoClass(unittest.TestCase):
         hyp.plot_hypnogram(fill_color="cornflowerblue", highlight="N3", lw=0.5)
         plt.close("all")
         # Make sure mapping stays intact after plotting
-        assert hyp.mapping == {'SLEEP': 0, 'WAKE': 1, 'ART': -1, 'UNS': -2}
+        assert hyp.mapping == {"SLEEP": 0, "WAKE": 1, "ART": -1, "UNS": -2}
 
     def test_3stages_hypno(self):
         """Test 3-stages Hypnogram class"""

--- a/yasa/tests/test_hypnoclass.py
+++ b/yasa/tests/test_hypnoclass.py
@@ -129,6 +129,8 @@ class TestHypnoClass(unittest.TestCase):
         assert isinstance(hyp.plot_hypnogram(), plt.Axes)
         hyp.plot_hypnogram(fill_color="cornflowerblue", highlight="N3", lw=0.5)
         plt.close("all")
+        # Make sure mapping stays intact after plotting
+        assert hyp.mapping == {'SLEEP': 0, 'WAKE': 1, 'ART': -1, 'UNS': -2}
 
     def test_3stages_hypno(self):
         """Test 3-stages Hypnogram class"""

--- a/yasa/tests/test_hypnoclass.py
+++ b/yasa/tests/test_hypnoclass.py
@@ -34,7 +34,7 @@ class TestHypnoClass(unittest.TestCase):
         assert hyp.n_epochs == 240
         assert hyp.duration == 120
         assert hyp.n_stages == 2
-        assert hyp.labels == ["SLEEP", "WAKE", "ART", "UNS"]
+        assert hyp.labels == ["WAKE", "SLEEP", "ART", "UNS"]
         assert hyp.mapping == {"WAKE": 0, "SLEEP": 1, "ART": -1, "UNS": -2}
         assert hyp.start is None
         assert hyp.scorer is None

--- a/yasa/tests/test_plotting.py
+++ b/yasa/tests/test_plotting.py
@@ -4,6 +4,7 @@ import unittest
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+from yasa.hypno import simulate_hypno
 from yasa.plotting import topoplot, plot_hypnogram
 
 
@@ -36,26 +37,28 @@ class TestPlotting(unittest.TestCase):
 
     def test_plot_hypnogram(self):
         """Test plot_hypnogram function."""
-        # Default parameters
-        hypno = np.loadtxt("notebooks/data_full_6hrs_100Hz_hypno_30s.txt")
-        _ = plot_hypnogram(hypno)
-        # Adding fill color
-        _ = plot_hypnogram(hypno, fill_color="gainsboro")
-        # Draw on an existing axis.
-        hypno = pd.Series(np.repeat([0, 1, 2, 3, 4, 0], 120))
-        ax = plt.subplot()
-        _ = plot_hypnogram(hypno, ax=ax)
-        # Changing the lw and sf_hypno
-        hypno = list(np.repeat([0, 0, -1, -1, 0, 0, 1, 2, 3, 4, 0, 0, 0], 120))
-        _ = plot_hypnogram(hypno, sf_hypno=1 / 10, lw=2.5)
-        # With Unscored
-        hypno = np.repeat([0, 1, 2, 3, 4, 0, -2], 120)
-        _ = plot_hypnogram(hypno)
-        # With both Art and Uns
-        hypno = np.repeat([-2, -2, -2, 0, -1, 0, 1, 2, 2, 2, 3, 3, 3, 4, -2, -2], 30)
-        _ = plot_hypnogram(hypno)
-        # Error because of "-3"
+        # Error because of input is not a yasa.Hypnogram
         with pytest.raises(AssertionError):
-            hypno = np.repeat([0, 1, 2, 3, 4, -2, -1, -3], 120)
-            _ = plot_hypnogram(hypno)
+            _ = plot_hypnogram(np.repeat([0, 1, 2, 3, 4, -2, -1, -3], 120))
+        # Default parameters
+        hyp5 = simulate_hypno(n_stages=5)
+        hyp2 = simulate_hypno(n_stages=2)
+        ax = hyp5.plot_hypnogram()
+        assert isinstance(ax, plt.Axes)
+        # Aesthetic parameters
+        _ = hyp5.plot_hypnogram(fill_color="gainsboro")
+        _ = hyp5.plot_hypnogram(fill_color="gainsboro", highlight="REM")
+        _ = hyp2.plot_hypnogram(fill_color="gainsboro", highlight="SLEEP")
+        _ = hyp2.plot_hypnogram(fill_color="gainsboro", highlight="SLEEP", lw=3)
+        # Draw on an existing axis.
+        ax = plt.subplot()
+        _ = hyp5.plot_hypnogram(ax=ax)
+        # With datetime axis
+        hyp3 = simulate_hypno(n_stages=3, tib=800, start="2020-01-01 20:00:00")
+        hyp3.plot_hypnogram()
+        # With Artefacts and Unscored
+        hyp3.hypno.iloc[-100:] = "UNS"
+        hyp3.hypno.loc["2020-01-01 22:10:00":"2020-01-01 22:15:00"] = "ART"
+        hyp3.hypno.loc["2020-01-01 23:30:00":"2020-01-02 01:00:00"] = "ART"
+        hyp3.plot_hypnogram(fill_color="peachpuff")
         plt.close("all")

--- a/yasa/tests/test_spectral.py
+++ b/yasa/tests/test_spectral.py
@@ -8,7 +8,7 @@ from scipy.signal import welch
 import matplotlib.pyplot as plt
 
 from yasa.plotting import plot_spectrogram
-from yasa.hypno import hypno_int_to_str, hypno_str_to_int, hypno_upsample_to_data, Hypnogram
+from yasa.hypno import hypno_str_to_int, hypno_upsample_to_data
 from yasa.spectral import (
     bandpower,
     bandpower_from_psd,
@@ -27,10 +27,6 @@ data_full = file_full.get("data")
 chan_full = file_full.get("chan")
 sf_full = 100
 hypno_full = np.load("notebooks/data_full_6hrs_100Hz_hypno.npz").get("hypno")
-
-# Convert to Hypnogram for plotting
-hypno_full_str = hypno_int_to_str(hypno_full)
-hyp_full = Hypnogram(hypno_full_str, freq="10ms")
 
 # Using MNE
 data_mne = mne.io.read_raw_fif("notebooks/sub-02_mne_raw.fif", preload=True, verbose=0)
@@ -156,16 +152,17 @@ class TestSpectral(unittest.TestCase):
     def test_plot_spectrogram(self):
         """Test function plot_spectrogram"""
         plot_spectrogram(data_full[0, :], sf_full, fmin=0.5, fmax=30)
-        plot_spectrogram(data_full[0, :], sf_full, hyp_full, trimperc=5)
+        plot_spectrogram(data_full[0, :], sf_full, hypno_full, trimperc=5)
         plot_spectrogram(data_full[0, :], sf_full, fmin=0.5, fmax=30, vmin=-50, vmax=100)
+        hypno_full_art = np.copy(hypno_full)
+        hypno_full_art[hypno_full_art == 3.0] = -1
         # Replace N3 by Artefact
-        hyp_full.hypno.loc[hyp_full.hypno.eq("N3")] = "ART"
-        plot_spectrogram(data_full[0, :], sf_full, hyp_full, trimperc=5)
+        plot_spectrogram(data_full[0, :], sf_full, hypno_full_art, trimperc=5)
         # Now replace REM by Unscored
-        hyp_full.hypno.loc[hyp_full.hypno.eq("REM")] = "UNS"
-        plot_spectrogram(data_full[0, :], sf_full, hyp_full)
+        hypno_full_art[hypno_full_art == 4.0] = -2
+        plot_spectrogram(data_full[0, :], sf_full, hypno_full_art)
         # Pass kwargs to the hypnogram plot
-        plot_spectrogram(data_full[0, :], sf_full, hyp_full, lw=1, fill_color="blue")
+        plot_spectrogram(data_full[0, :], sf_full, hypno_full_art, lw=1, fill_color="blue")
         plt.close("all")
         # Errors
         with pytest.raises(AssertionError):


### PR DESCRIPTION
This PR brings `yasa.plot_hypnogram` up to speed with the new `yasa.Hypnogram` class (Issue #116). See Issue #122 for more details.

Main changes:
* `yasa.plot_hypnogram` does not accept int/str sequence hypnograms anymore. Input _must_ be a Hypnogram instance.
* The function `yasa.plot_hypnogram` still exists, but should mostly be considered a utility function at this point. The user should always plot with `yasa.Hypnogram.plot_hypnogram`
* `plot_hypnogram` handles any valid `n_stages`
* `plot_hypnogram` takes a `highlight` parameter where any valid stage label can be passed for a red highlight (this used to be automatic to REM, but with variable `n_stages` options this might differ among use-cases).
* The hypnogram plot x-axis will have a datetime axis with time as HH:MM if the Hypnogram instance has a `start` value.
* `yasa.plot_spectrogram` now accepts an optional `hyp` Hypnogram, as opposed to an optional `hypno` array.

I didn't update any Jupyter notebooks. That feels like it would be easier to do all at once after all the new functions properly handle Hypnogram objects? Maybe as a final step?

Sidenote: Currently, `yasa.Hypnogram.upsample_to_data` returns an array but `yasa.Hypnogram.upsample` returns another Hypnogram instance. Is that intended? It seems like they should both return another Hypnogram instance and then user can get the integer array as-needed. But maybe you have some other logic behind this.

btw, `yasa.Hypnogram.mapping` is awesome! Sorry @raphaelvallat when I originally reviewed #116 I wasn't familiar with Python setters and so didn't realize how powerful and simple this is.