### PR TITLE
Default dtype of pandas.Series is now a categorical

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,12 +11,12 @@ What's new
 v0.7.dev
 --------
 
-**Object-oriented hypnogram manipulation**
+**Object-oriented hypnogram**
 
-This version introduces the new :py:class:`yasa.Hypnogram` class, which will progressively become
+This version introduces the new :py:class:`yasa.Hypnogram` class, which will gradually become
 the standard way to store and manipulate hypnograms in YASA. Put simply, YASA now uses an
 object-oriented approach to hypnograms. That is, hypnograms are now stored as a class (aka object),
-which comes with several pre-built functions (named methods) and attributes. See for example below:
+which comes with several pre-built functions (aka methods) and attributes. See for example below:
 
 .. code-block::  python
 
@@ -25,7 +25,7 @@ which comes with several pre-built functions (named methods) and attributes. See
     values = ["W", "W", "W", "S", "S", "S", "S", "S", "W", "S", "S", "S"]
     hyp = Hypnogram(values, n_stages=2, start="2022-12-23 22:30:00", scorer="RM")
     # Below are some class attributes
-    hyp.hypno  # Hypnogram values (pandas Series)
+    hyp.hypno  # Hypnogram values (a pandas.Series of categorical dtype)
     hyp.duration  # Total duration of the hypnogram, in minutes
     hyp.sampling_frequency  # Sampling frequency of the hypnogram
     hyp.mapping  # Mapping from strings to integers

--- a/yasa/hypno.py
+++ b/yasa/hypno.py
@@ -19,7 +19,7 @@ __all__ = [
     "hypno_upsample_to_data",
     "hypno_find_periods",
     "load_profusion_hypno",
-    "simulate_hypno",
+    "simulate_hypnogram",
 ]
 
 
@@ -36,7 +36,7 @@ class Hypnogram:
     Instead, users must pass an array of strings with the actual stage names
     (e.g. ["WAKE", "WAKE", "N1", ..., "REM", "REM"]).
 
-    .. seealso:: :py:func:`yasa.simulate_hypno`
+    .. seealso:: :py:func:`yasa.simulate_hypnogram`
 
     .. versionadded:: 0.7.0
 
@@ -151,13 +151,13 @@ class Hypnogram:
     SLEEP          1      6
 
     All these methods and properties are also valid with a 5-stages hypnogram. In the example below,
-    we use the :py:func:`yasa.simulate_hypno` to generate a plausible 5-stages hypnogram with a
+    we use the :py:func:`yasa.simulate_hypnogram` to generate a plausible 5-stages hypnogram with a
     30-seconds resolution. A random seed is specified to ensure that we get reproducible results.
     Lastly, we set an actual start time to the hypnogram. As a result, the index of the resulting
     hypnogram is a :py:class:`pandas.DatetimeIndex`.
 
-    >>> from yasa import simulate_hypno
-    >>> hyp = simulate_hypno(
+    >>> from yasa import simulate_hypnogram
+    >>> hyp = simulate_hypnogram(
     ...     tib=500, n_stages=5, start="2022-12-15 22:30:00", scorer="S1", seed=42)
     >>> hyp  # This is a shortcut to `hyp.hypno`
     Time
@@ -597,8 +597,8 @@ class Hypnogram:
         This function is not limited to binary arrays, e.g. a 5-stages hypnogram at 30-sec
         resolution:
 
-        >>> from yasa import simulate_hypno
-        >>> hyp = simulate_hypno(tib=30, seed=42)
+        >>> from yasa import simulate_hypnogram
+        >>> hyp = simulate_hypnogram(tib=30, seed=42)
         >>> hyp.find_periods(threshold="2min")
           values  start  length
         0   WAKE      0       5
@@ -643,22 +643,22 @@ class Hypnogram:
         --------
         .. plot::
 
-            >>> from yasa import simulate_hypno
-            >>> ax = simulate_hypno(tib=480, seed=88).plot_hypnogram(highlight="REM")
+            >>> from yasa import simulate_hypnogram
+            >>> ax = simulate_hypnogram(tib=480, seed=88).plot_hypnogram(highlight="REM")
         """
         return plot_hypnogram(self, **kwargs)
 
     def simulate_similar(self, **kwargs):
         """Simulate a new hypnogram based on properties of the current hypnogram.
 
-        .. seealso:: :py:func:`yasa.simulate_hypno`
+        .. seealso:: :py:func:`yasa.simulate_hypnogram`
 
         Parameters
         ----------
         self : :py:class:`yasa.Hypnogram`
             Hypnogram, assumed to be already cropped to time in bed (TIB).
         **kwargs : dict
-            Optional keyword arguments passed to :py:func:`yasa.simulate_hypno`.
+            Optional keyword arguments passed to :py:func:`yasa.simulate_hypnogram`.
 
         Returns
         -------
@@ -693,7 +693,7 @@ class Hypnogram:
             "`n_stages` and `freq` cannot be included as additional `**kwargs` "
             "because they must match properties of the current Hypnogram."
         )
-        simulate_hypno_kwargs = {
+        simulate_hypnogram_kwargs = {
             "tib": self.duration,
             "n_stages": self.n_stages,
             "freq": self.freq,
@@ -701,8 +701,8 @@ class Hypnogram:
             "start": self.start,
             "scorer": self.scorer,
         }
-        simulate_hypno_kwargs.update(kwargs)
-        return simulate_hypno(**simulate_hypno_kwargs)
+        simulate_hypnogram_kwargs.update(kwargs)
+        return simulate_hypnogram(**simulate_hypnogram_kwargs)
 
     def sleep_statistics(self):
         """
@@ -773,9 +773,9 @@ class Hypnogram:
 
         Sleep statistics for a 5-stages hypnogram
 
-        >>> from yasa import simulate_hypno
+        >>> from yasa import simulate_hypnogram
         >>> # Generate a 8 hr (= 480 minutes) 5-stages hypnogram with a 30-seconds resolution
-        >>> hyp = simulate_hypno(tib=480, seed=42)
+        >>> hyp = simulate_hypnogram(tib=480, seed=42)
         >>> hyp.sleep_statistics()
         {'TIB': 480.0,
         'SPT': 477.5,
@@ -904,9 +904,9 @@ class Hypnogram:
 
         Examples
         --------
-        >>> from yasa import Hypnogram, simulate_hypno
+        >>> from yasa import Hypnogram, simulate_hypnogram
         >>> # Generate a 8 hr (= 480 minutes) 5-stages hypnogram with a 30-seconds resolution
-        >>> hyp = simulate_hypno(tib=480, seed=42)
+        >>> hyp = simulate_hypnogram(tib=480, seed=42)
         >>> counts, probs = hyp.transition_matrix()
         >>> counts
         To Stage    WAKE  N1   N2  N3  REM
@@ -1517,7 +1517,7 @@ def hypno_find_periods(hypno, sf_hypno, threshold="5min", equal_length=False):
 #############################################################################
 
 
-def simulate_hypno(
+def simulate_hypnogram(
     tib=480,
     trans_probas=None,
     init_probas=None,
@@ -1597,8 +1597,8 @@ def simulate_hypno(
 
     Examples
     --------
-    >>> from yasa import simulate_hypno
-    >>> hyp = simulate_hypno(tib=5, seed=1)
+    >>> from yasa import simulate_hypnogram
+    >>> hyp = simulate_hypnogram(tib=5, seed=1)
     >>> print(hyp)
     Epoch
     0    WAKE
@@ -1613,7 +1613,7 @@ def simulate_hypno(
     9      N2
     Name: Stage, dtype: object
 
-    >>> hyp = simulate_hypno(tib=5, n_stages=2, seed=1)
+    >>> hyp = simulate_hypnogram(tib=5, n_stages=2, seed=1)
     >>> print(hyp)
     Epoch
     0     WAKE
@@ -1630,7 +1630,7 @@ def simulate_hypno(
 
     Add some Unscored epochs.
 
-    >>> hyp = simulate_hypno(tib=5, n_stages=2, seed=1)
+    >>> hyp = simulate_hypnogram(tib=5, n_stages=2, seed=1)
     >>> hyp.hypno.iloc[-2:] = "UNS"
     >>> print(hyp)
     Epoch

--- a/yasa/plotting.py
+++ b/yasa/plotting.py
@@ -41,9 +41,9 @@ def plot_hypnogram(hyp, lw=1.5, highlight="REM", fill_color=None, ax=None):
     --------
     .. plot::
 
-        >>> from yasa import simulate_hypno
+        >>> from yasa import simulate_hypnogram
         >>> import matplotlib.pyplot as plt
-        >>> hyp = simulate_hypno(tib=300, seed=11)
+        >>> hyp = simulate_hypnogram(tib=300, seed=11)
         >>> ax = hyp.plot_hypnogram()
         >>> plt.tight_layout()
 
@@ -58,8 +58,8 @@ def plot_hypnogram(hyp, lw=1.5, highlight="REM", fill_color=None, ax=None):
     .. plot::
 
         >>> fig, axes = plt.subplots(nrows=2, figsize=(6, 4), constrained_layout=True)
-        >>> hyp_a = simulate_hypno(n_stages=3, seed=99)
-        >>> hyp_b = simulate_hypno(n_stages=3, seed=99, start="2022-01-31 23:30:00")
+        >>> hyp_a = simulate_hypnogram(n_stages=3, seed=99)
+        >>> hyp_b = simulate_hypnogram(n_stages=3, seed=99, start="2022-01-31 23:30:00")
         >>> hyp_a.plot_hypnogram(lw=1, fill_color="whitesmoke", highlight=None, ax=axes[0])
         >>> hyp_b.plot_hypnogram(lw=1, fill_color="whitesmoke", highlight=None, ax=axes[1])
     """

--- a/yasa/tests/test_hypnoclass.py
+++ b/yasa/tests/test_hypnoclass.py
@@ -148,7 +148,7 @@ class TestHypnoClass(unittest.TestCase):
         assert "Lat_REM" in sstats.keys()
 
         # Try to set a value that is not a valid category
-        with pytest.raises(TypeError):
+        with pytest.raises((TypeError, ValueError)):  # TypeError in newer versions of Pandas
             hyp.hypno.loc[0] = "Dream sleep"
 
     def test_4stages_hypno(self):

--- a/yasa/tests/test_hypnoclass.py
+++ b/yasa/tests/test_hypnoclass.py
@@ -1,5 +1,6 @@
 """Test the class Hypnogram."""
 import mne
+import pytest
 import unittest
 import numpy as np
 import pandas as pd
@@ -28,6 +29,7 @@ class TestHypnoClass(unittest.TestCase):
         # Check properties
         np.testing.assert_array_equal(hyp.hypno.str.get(0)[:10], np.repeat(["W", "S"], 5))
         assert isinstance(hyp.hypno.index, pd.RangeIndex)
+        assert hyp.hypno.dtype == "category"
         assert hyp.hypno.index.name == "Epoch"
         assert hyp.sampling_frequency == 1 / 30
         assert hyp.freq == "30s"
@@ -104,7 +106,7 @@ class TestHypnoClass(unittest.TestCase):
         hyp_up = hyp.upsample_to_data(raw)
         assert isinstance(hyp_up, np.ndarray)
         assert hyp_up.size == npts
-        assert hyp_up.dtype == int
+        assert hyp_up.dtype == np.int16
         hyp_up = hyp.upsample_to_data(raw.get_data(), sf=100)
 
         # yasa.Hypnogram.simulate_similar
@@ -144,6 +146,10 @@ class TestHypnoClass(unittest.TestCase):
         assert sstats["TIB"] == 120
         assert "%REM" in sstats.keys()
         assert "Lat_REM" in sstats.keys()
+
+        # Try to set a value that is not a valid category
+        with pytest.raises(TypeError):
+            hyp.hypno.loc[0] = "Dream sleep"
 
     def test_4stages_hypno(self):
         """Test 4-stages Hypnogram class"""

--- a/yasa/tests/test_hypnoclass.py
+++ b/yasa/tests/test_hypnoclass.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
-from yasa.hypno import simulate_hypno, Hypnogram, hypno_str_to_int
+from yasa.hypno import simulate_hypnogram, Hypnogram, hypno_str_to_int
 
 
 def create_raw(npts, ch_names=["F4-M1", "F3-M2"], sf=100):
@@ -22,7 +22,7 @@ class TestHypnoClass(unittest.TestCase):
 
     def test_2stages_hypno(self):
         """Test 2-stages Hypnogram class"""
-        hyp = simulate_hypno(tib=120, n_stages=2, seed=42)
+        hyp = simulate_hypnogram(tib=120, n_stages=2, seed=42)
         print(hyp)
         print(str(hyp))
 
@@ -123,7 +123,7 @@ class TestHypnoClass(unittest.TestCase):
         assert hyp.simulate_similar(tib=2, scorer="YASA").scorer == "YASA"
         assert hyp.simulate_similar(tib=2, start="2022-11-10").start == "2022-11-10"
         np.testing.assert_array_equal(
-            simulate_hypno(seed=1).simulate_similar(tib=5, seed=6).as_int(),
+            simulate_hypnogram(seed=1).simulate_similar(tib=5, seed=6).as_int(),
             [0, 0, 0, 0, 1, 1, 1, 2, 2, 2],
         )
 
@@ -136,7 +136,7 @@ class TestHypnoClass(unittest.TestCase):
 
     def test_3stages_hypno(self):
         """Test 3-stages Hypnogram class"""
-        hyp = simulate_hypno(tib=120, n_stages=3, freq="1s", seed=42)
+        hyp = simulate_hypnogram(tib=120, n_stages=3, freq="1s", seed=42)
         assert hyp.sampling_frequency == 1
         assert hyp.freq == "1s"
         assert hyp.n_stages == 3
@@ -153,7 +153,7 @@ class TestHypnoClass(unittest.TestCase):
 
     def test_4stages_hypno(self):
         """Test 4-stages Hypnogram class"""
-        hyp = simulate_hypno(tib=400, n_stages=4, freq="30s", seed=42)
+        hyp = simulate_hypnogram(tib=400, n_stages=4, freq="30s", seed=42)
         assert hyp.n_stages == 4
         assert hyp.labels == ["WAKE", "LIGHT", "DEEP", "REM", "ART", "UNS"]
         assert hyp.mapping == {"WAKE": 0, "LIGHT": 2, "DEEP": 3, "REM": 4, "ART": -1, "UNS": -2}
@@ -165,7 +165,7 @@ class TestHypnoClass(unittest.TestCase):
 
     def test_5stages_hypno(self):
         """Test 5-stages Hypnogram class"""
-        hyp = simulate_hypno(tib=600, n_stages=5, freq="30s", seed=42)
+        hyp = simulate_hypnogram(tib=600, n_stages=5, freq="30s", seed=42)
         assert hyp.n_stages == 5
         assert hyp.labels == ["WAKE", "N1", "N2", "N3", "REM", "ART", "UNS"]
         assert hyp.mapping == {

--- a/yasa/tests/test_plotting.py
+++ b/yasa/tests/test_plotting.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
-from yasa.hypno import simulate_hypno
+from yasa.hypno import simulate_hypnogram
 from yasa.plotting import topoplot, plot_hypnogram
 
 
@@ -41,8 +41,8 @@ class TestPlotting(unittest.TestCase):
         with pytest.raises(AssertionError):
             _ = plot_hypnogram(np.repeat([0, 1, 2, 3, 4, -2, -1, -3], 120))
         # Default parameters
-        hyp5 = simulate_hypno(n_stages=5)
-        hyp2 = simulate_hypno(n_stages=2)
+        hyp5 = simulate_hypnogram(n_stages=5)
+        hyp2 = simulate_hypnogram(n_stages=2)
         ax = hyp5.plot_hypnogram()
         assert isinstance(ax, plt.Axes)
         # Aesthetic parameters
@@ -54,7 +54,7 @@ class TestPlotting(unittest.TestCase):
         ax = plt.subplot()
         _ = hyp5.plot_hypnogram(ax=ax)
         # With datetime axis
-        hyp3 = simulate_hypno(n_stages=3, tib=800, start="2020-01-01 20:00:00")
+        hyp3 = simulate_hypnogram(n_stages=3, tib=800, start="2020-01-01 20:00:00")
         hyp3.plot_hypnogram()
         # With Artefacts and Unscored
         hyp3.hypno.iloc[-100:] = "UNS"


### PR DESCRIPTION
Closes #125 

This PR:

- changes the default dtype of `hyp.hypno` as a [pandas.CategoricalDtype](https://pandas.pydata.org/docs/reference/api/pandas.CategoricalDtype.html)
- set the default return dtype from np.int64 to np.int16 in `Hypnogram.as_int()`
- fixes a few typos and improves docstrings

Hopefully this should be pretty straightforward to review. Let me know if you have any questions! We're so close :)