### PR TITLE
Update mne.pick_channels() to mne.pick()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ If you have sleep EEG data in standard formats (e.g. EDF or BrainVision), you ca
   # Apply a bandpass filter from 0.1 to 40 Hz
   raw.filter(0.1, 40)
   # Select a subset of EEG channels
-  raw.pick_channels(['C4-A1', 'C3-A2'])
+  raw.pick(['C4-A1', 'C3-A2'])
 
 How do I get started with YASA?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -31,7 +31,7 @@ If you have polysomnography data in European Data Format (.edf), you can use the
   # Apply a bandpass filter from 0.1 to 40 Hz
   raw.filter(0.1, 40)
   # Select a subset of EEG channels
-  raw.pick_channels(['C4-A1', 'C3-A2'])
+  raw.pick(['C4-A1', 'C3-A2'])
 
 .. ----------------------------- VISUALIZE -----------------------------
 .. raw:: html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,7 +70,7 @@ If you have sleep EEG data in standard formats (e.g. EDF or BrainVision), you ca
   # Apply a bandpass filter from 0.1 to 40 Hz
   raw.filter(0.1, 40)
   # Select a subset of EEG channels
-  raw.pick_channels(['C4-A1', 'C3-A2'])
+  raw.pick(['C4-A1', 'C3-A2'])
 
 **********
 

--- a/notebooks/08_bandpower.ipynb
+++ b/notebooks/08_bandpower.ipynb
@@ -1881,7 +1881,7 @@
    ],
    "source": [
     "# Single channel bandpower\n",
-    "yasa.bandpower(raw.copy().pick_channels(['F3']), hypno=hypno_up, include=(2, 3), bandpass=True)"
+    "yasa.bandpower(raw.copy().pick(['F3']), hypno=hypno_up, include=(2, 3), bandpass=True)"
    ]
   },
   {

--- a/notebooks/16_EEG-HRV_coupling.ipynb
+++ b/notebooks/16_EEG-HRV_coupling.ipynb
@@ -139,7 +139,7 @@
     "# Use MNE to load the EDF file\n",
     "raw = mne.io.read_raw_edf(path_edf, preload=True, verbose=False)\n",
     "# Keep only one EEG channel (C4-A1) and one ECG\n",
-    "raw.pick_channels(['C4-A1', 'EKG-R-EKG-L'], ordered=True)\n",
+    "raw.pick(['C4-A1', 'EKG-R-EKG-L'], ordered=True)\n",
     "raw"
    ]
   },

--- a/yasa/staging.py
+++ b/yasa/staging.py
@@ -1,16 +1,4 @@
 """Automatic sleep staging of polysomnography data."""
-#  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-#   Copyright (c) 2024. Simon J. Guillot. All rights reserved.                            +
-#   Redistribution and use in source and binary forms, with or without modification, are strictly prohibited.
-#                                                                                         +
-#   THIS CODE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
-#   BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-#   IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-#   OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-#   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-#   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS CODE,
-#   EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 import os
 import mne

--- a/yasa/staging.py
+++ b/yasa/staging.py
@@ -1,5 +1,4 @@
 """Automatic sleep staging of polysomnography data."""
-
 import os
 import mne
 import glob

--- a/yasa/staging.py
+++ b/yasa/staging.py
@@ -188,7 +188,7 @@ class SleepStaging:
         ch_names = ch_names[keep_chan].tolist()
         ch_types = ch_types[keep_chan].tolist()
         # Keep only selected channels (creating a copy of Raw)
-        raw_pick = raw.copy().pick(ch_names, ordered=True)
+        raw_pick = raw.copy().pick(ch_names)
 
         # Downsample if sf != 100
         assert sf > 80, "Sampling frequency must be at least 80 Hz."

--- a/yasa/staging.py
+++ b/yasa/staging.py
@@ -1,4 +1,17 @@
 """Automatic sleep staging of polysomnography data."""
+#  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#   Copyright (c) 2024. Simon J. Guillot. All rights reserved.                            +
+#   Redistribution and use in source and binary forms, with or without modification, are strictly prohibited.
+#                                                                                         +
+#   THIS CODE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+#   BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+#   IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+#   OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+#   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS CODE,
+#   EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
 import os
 import mne
 import glob
@@ -188,7 +201,7 @@ class SleepStaging:
         ch_names = ch_names[keep_chan].tolist()
         ch_types = ch_types[keep_chan].tolist()
         # Keep only selected channels (creating a copy of Raw)
-        raw_pick = raw.copy().pick_channels(ch_names, ordered=True)
+        raw_pick = raw.copy().pick(ch_names, ordered=True)
 
         # Downsample if sf != 100
         assert sf > 80, "Sampling frequency must be at least 80 Hz."

--- a/yasa/tests/test_detection.py
+++ b/yasa/tests/test_detection.py
@@ -1,16 +1,4 @@
 """Test the functions in yasa/spectral.py."""
-#  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-#   Copyright (c) 2024. Simon J. Guillot. All rights reserved.                            +
-#   Redistribution and use in source and binary forms, with or without modification, are strictly prohibited.
-#                                                                                         +
-#   THIS CODE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
-#   BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-#   IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-#   OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-#   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-#   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS CODE,
-#   EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 import mne
 import pytest

--- a/yasa/tests/test_detection.py
+++ b/yasa/tests/test_detection.py
@@ -1,4 +1,17 @@
 """Test the functions in yasa/spectral.py."""
+#  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#   Copyright (c) 2024. Simon J. Guillot. All rights reserved.                            +
+#   Redistribution and use in source and binary forms, with or without modification, are strictly prohibited.
+#                                                                                         +
+#   THIS CODE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+#   BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+#   IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+#   OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+#   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS CODE,
+#   EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
 import mne
 import pytest
 import unittest
@@ -41,7 +54,7 @@ hypno_sw = hypno_full[666000:672000]
 # MNE Raw
 data_mne = mne.io.read_raw_fif("notebooks/sub-02_mne_raw.fif", preload=True, verbose=0)
 data_mne.pick_types(eeg=True)
-data_mne_single = data_mne.copy().pick_channels(["F3"])
+data_mne_single = data_mne.copy().pick(["F3"])
 hypno_mne = np.loadtxt("notebooks/sub-02_hypno_30s.txt", dtype=str)
 hypno_mne = hypno_str_to_int(hypno_mne)
 hypno_mne = hypno_upsample_to_data(hypno=hypno_mne, sf_hypno=(1 / 30), data=data_mne)

--- a/yasa/tests/test_detection.py
+++ b/yasa/tests/test_detection.py
@@ -1,5 +1,4 @@
 """Test the functions in yasa/spectral.py."""
-
 import mne
 import pytest
 import unittest

--- a/yasa/tests/test_others.py
+++ b/yasa/tests/test_others.py
@@ -1,5 +1,4 @@
 """Test the functions in the yasa/others.py file."""
-
 import mne
 import unittest
 import numpy as np

--- a/yasa/tests/test_others.py
+++ b/yasa/tests/test_others.py
@@ -1,4 +1,17 @@
 """Test the functions in the yasa/others.py file."""
+#  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#   Copyright (c) 2024. Simon J. Guillot. All rights reserved.                            +
+#   Redistribution and use in source and binary forms, with or without modification, are strictly prohibited.
+#                                                                                         +
+#   THIS CODE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+#   BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+#   IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+#   OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+#   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS CODE,
+#   EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
 import mne
 import unittest
 import numpy as np
@@ -31,7 +44,7 @@ hypno_full = np.load("notebooks/data_full_6hrs_100Hz_hypno.npz").get("hypno")
 # Using MNE
 data_mne = mne.io.read_raw_fif("notebooks/sub-02_mne_raw.fif", preload=True, verbose=0)
 data_mne.pick_types(eeg=True)
-data_mne_single = data_mne.copy().pick_channels(["F3"])
+data_mne_single = data_mne.copy().pick(["F3"])
 hypno_mne = np.loadtxt("notebooks/sub-02_hypno_30s.txt", dtype=str)
 hypno_mne = hypno_str_to_int(hypno_mne)
 hypno_mne = hypno_upsample_to_data(hypno=hypno_mne, sf_hypno=(1 / 30), data=data_mne)

--- a/yasa/tests/test_others.py
+++ b/yasa/tests/test_others.py
@@ -1,16 +1,4 @@
 """Test the functions in the yasa/others.py file."""
-#  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-#   Copyright (c) 2024. Simon J. Guillot. All rights reserved.                            +
-#   Redistribution and use in source and binary forms, with or without modification, are strictly prohibited.
-#                                                                                         +
-#   THIS CODE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
-#   BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-#   IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-#   OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-#   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-#   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS CODE,
-#   EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 import mne
 import unittest


### PR DESCRIPTION
Update mne.pick_channels() to mne.pick(), as mne.pick_channels() is a legacy function.

I wasn't sure how to deal with the changelog as I only updated mne.pick() which works just like mne.pick_channels().

@raphaelvallat, if you have a moment to review?