### PR TITLE
Updated deprecated functions

### DIFF
--- a/yasa/hypno.py
+++ b/yasa/hypno.py
@@ -482,7 +482,7 @@ class Hypnogram:
         Name: Stage, dtype: int16
         """
         # Return as int16 (-32768 to 32767) to reduce memory usage
-        return self.hypno.replace(self.mapping).astype(np.int16)
+        return self.hypno.cat.rename_categories(self.mapping).astype(np.int16)
 
     def consolidate_stages(self, new_n_stages):
         """Reduce the number of stages in a hypnogram to match actigraphy or wearables.

--- a/yasa/plotting.py
+++ b/yasa/plotting.py
@@ -331,7 +331,7 @@ def plot_spectrogram(
 
     if hypno is not None:
         # Convert sampling frequency to pandas timefrequency string (e.g., "30s")
-        freq_str = pd.tseries.frequencies.to_offset(pd.Timedelta(1 / sf, "S")).freqstr
+        freq_str = pd.tseries.frequencies.to_offset(pd.Timedelta(1 / sf, "s")).freqstr
         # Create Hypnogram instance for plotting
         hyp = Hypnogram(hypno_int_to_str(hypno), freq=freq_str)
         hypnoplot_kwargs = dict(lw=1.5, fill_color=None)


### PR DESCRIPTION
Updated deprecated functions:
- `Series.replace()` to `Series.cat.rename_categories()`
- `pd.Timedelta('S')` to `pd.Timedelta('s')`