### PR TITLE
bump lspopt version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "pyriemann>=0.2.7",
     "sleepecg>=0.5.0",
     "setuptools>=70",
-    "lspopt",
+    "lspopt>=1.4",
     "ipywidgets",
     "joblib",
     "lightgbm",


### PR DESCRIPTION
Fixes `lspopt` deprecation warning in #190 by requiring `lspopt>=1.4`. This doesn't really risk anything because lspopt itself has minimal dependencies (just early numpy and scipy versions).