### PR TITLE
Fix 404 page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@
 * Spectral analyses: bandpower, phase-amplitude coupling, 1/f slope, and more!
 * Hypnogram analysis: sleep statistics and stage transitions.
 
-For more details, try the `quickstart <https://raphaelvallat.com/yasa/build/html/quickstart.html>`_ or read the `FAQ <https://raphaelvallat.com/yasa/build/html/faq.html>`_.
+For more details, try the `quickstart <https://raphaelvallat.com/yasa/quickstart.html>`_ or read the `FAQ <https://raphaelvallat.com/yasa/faq.html>`_.
 
 ----------------
 
@@ -88,7 +88,7 @@ If you have sleep EEG data in standard formats (e.g. EDF or BrainVision), you ca
 How do I get started with YASA?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want to dive right in, you can simply go to the main `documentation <https://raphaelvallat.com/yasa/build/html/quickstart.html>`_ and try to apply YASA's functions on your own EEG data.
+If you want to dive right in, you can simply go to the main `documentation <https://raphaelvallat.com/yasa/quickstart.html>`_ and try to apply YASA's functions on your own EEG data.
 However, for most users, we strongly recommend that you first try running the examples Jupyter notebooks to get a sense of how YASA works and what it can do!
 The notebooks also come with example datasets so they should work right out of the box as long as you've installed YASA first.
 The notebooks and datasets can be found on `GitHub <https://github.com/raphaelvallat/yasa/tree/master/notebooks>`_ (make sure that you download the whole *notebooks/* folder). A short description of all notebooks is provided below:

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@
 * Spectral analyses: bandpower, phase-amplitude coupling, 1/f slope, and more!
 * Hypnogram analysis: sleep statistics and stage transitions.
 
-For more details, try the `quickstart <https://raphaelvallat.com/yasa/quickstart.html>`_ or read the `FAQ <https://raphaelvallat.com/yasa/faq.html>`_.
+For more details, try the `quickstart <https://raphaelvallat.github.io/yasa/quickstart.html>`_ or read the `FAQ <https://raphaelvallat.github.io/yasa/faq.html>`_.
 
 ----------------
 
@@ -88,7 +88,7 @@ If you have sleep EEG data in standard formats (e.g. EDF or BrainVision), you ca
 How do I get started with YASA?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want to dive right in, you can simply go to the main `documentation <https://raphaelvallat.com/yasa/quickstart.html>`_ and try to apply YASA's functions on your own EEG data.
+If you want to dive right in, you can simply go to the main `documentation <https://raphaelvallat.github.io/yasa/quickstart.html>`_ and try to apply YASA's functions on your own EEG data.
 However, for most users, we strongly recommend that you first try running the examples Jupyter notebooks to get a sense of how YASA works and what it can do!
 The notebooks also come with example datasets so they should work right out of the box as long as you've installed YASA first.
 The notebooks and datasets can be found on `GitHub <https://github.com/raphaelvallat/yasa/tree/master/notebooks>`_ (make sure that you download the whole *notebooks/* folder). A short description of all notebooks is provided below:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -207,7 +207,7 @@ Artefact and Unscored epochs are now excluded from the calculation of the total 
 
 **New FAQ**
 
-The online documentation now has a brand new FAQ section! Make sure to check it out at https://raphaelvallat.com/yasa/build/html/faq.html
+The online documentation now has a brand new FAQ section! Make sure to check it out at https://raphaelvallat.com/yasa/faq.html
 
 **New function: coincidence matrix**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -207,7 +207,7 @@ Artefact and Unscored epochs are now excluded from the calculation of the total 
 
 **New FAQ**
 
-The online documentation now has a brand new FAQ section! Make sure to check it out at https://raphaelvallat.com/yasa/faq.html
+The online documentation now has a brand new FAQ section! Make sure to check it out at https://raphaelvallat.github.io/yasa/faq.html
 
 **New function: coincidence matrix**
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -322,6 +322,11 @@ html_theme_options = {
 # html_title = f"{project} v{version}"  # defaults to "<project> v<revision> documentation"
 # html_short_title = f"{project} v{release}"  # used in the navbar if not using pydata logo
 
+# The base URL which points to the root of the HTML documentation.
+# It is used to indicate the location of document using the Canonical Link Relation.
+# Defaults to ""
+html_baseurl = "https://raphaelvallat.com/yasa"
+
 # A dictionary of values to pass into the template engine's context for all pages.
 # Defaults to {}
 html_context = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -669,3 +669,33 @@ numpydoc_class_members_toctree = True
 # If it’s False, the Attributes section will be formatted as the Methods section using an autosummary table.
 # Options: True (default) | False
 numpydoc_attributes_as_param_list = True
+
+# -- External extensions -----------------------------------------------------
+# -- -> Options for notfound.extension -------------------------------------------------
+# https://sphinx-notfound-page.readthedocs.io/en/latest/configuration.html
+
+# Context passed to the template defined by `notfound_template` or auto-generated.
+notfound_context = {
+    "title": "Page not found",
+    "body": """
+        <h1>This page may have moved.</h1>
+        <p>
+            The YASA documentation site has recently been upgraded!
+            Some URLs have changed.
+        </p>
+        <p>
+            Browse the <bold>Navigation menu</bold> or use the
+            <bold>Search button</bold> to find the page you were looking for.
+        </p>
+        <p>
+            Please update the URLs of any bookmarks or autofills in your
+            browser that point to the YASA documentation site.
+        </p>
+    """,
+}
+
+# Prefix added to all the URLs generated in the 404 page.
+# Defaults to READTHEDOCS env variable, typically "/en/latest/"
+# Note special case when using default GitHub pages URL: "/<repo>/"
+# https://sphinx-notfound-page.readthedocs.io/en/latest/faq.html#does-this-extension-work-with-github-pages
+notfound_urls_prefix = "/yasa/"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,6 +71,7 @@ extensions = [
     "numpydoc",                 # Generates numPy style docstrings (Needs to be loaded *after* autodoc)
     "sphinx_copybutton",        # Adds copy-to-clipboard button in code blocks
     "sphinx_design",            # Adds directives for badges, dropdowns, tabs, etc
+    "sphinx_reredirects",       # Generates redirects for moved pages
 
 ]
 
@@ -684,18 +685,9 @@ notfound_context = {
     "title": "Page not found",
     "body": """
         <h1>This page may have moved.</h1>
-        <p>
-            The YASA documentation site has recently been upgraded!
-            Some URLs have changed.
-        </p>
-        <p>
-            Browse the <bold>Navigation menu</bold> or use the
-            <bold>Search button</bold> to find the page you were looking for.
-        </p>
-        <p>
-            Please update the URLs of any bookmarks or autofills in your
-            browser that point to the YASA documentation site.
-        </p>
+        <p>The YASA documentation site has recently been upgraded! Some URLs have changed.</p>
+        <p>Navigate the menu or search to find the page you were looking for.</p>
+        <p>Please update any bookmarks or autofills that point to the YASA documentation site.</p>
     """,
 }
 
@@ -704,3 +696,25 @@ notfound_context = {
 # Note special case when using default GitHub pages URL: "/<repo>/"
 # https://sphinx-notfound-page.readthedocs.io/en/latest/faq.html#does-this-extension-work-with-github-pages
 notfound_urls_prefix = "/yasa/"
+
+# -- External extensions -----------------------------------------------------
+# -- -> Options for sphinx_reredirects -------------------------------------------------
+# https://documatt.com/sphinx-reredirects/usage.html
+# Defaults to {}
+redirects = {}
+
+# TEMPORARY: This can be removed after people stop using old links.
+# We need to generate a list of redirects for the old documentation
+# that was hosted under relative paths behind buid/html.
+# Create a sphinx extension that will find all docs and generate a
+# redirects dictionary that maps build/html/docpath to just docpath.
+def setup(app):
+    app.connect("env-updated", generate_redirects)
+
+def generate_redirects(app, env):
+    redirects = app.config.redirects or {}
+    for docpath in env.found_docs:
+        old_path = f"build/html/{docpath}"
+        new_path = "../" * old_path.count("/") + f"{docpath}.html"
+        redirects[old_path] = new_path
+    app.config.redirects = redirects

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -86,7 +86,7 @@ Event detection
     :icon: question
     :name: edit_detection
 
-    YASA does not currently support visual editing of the detected events. However, you can import the events as annotations in `EDFBrowser <https://www.teuniz.net/edfbrowser/>`_ and edit the events from there. If you simply want to visualize the detected events (no editing), you can also use the `plot_detection <https://raphaelvallat.com/yasa/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.plot_detection>`_ method.
+    YASA does not currently support visual editing of the detected events. However, you can import the events as annotations in `EDFBrowser <https://www.teuniz.net/edfbrowser/>`_ and edit the events from there. If you simply want to visualize the detected events (no editing), you can also use the `plot_detection <https://raphaelvallat.github.io/yasa/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.plot_detection>`_ method.
 
 
 .. ############################################################################

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -86,7 +86,7 @@ Event detection
     :icon: question
     :name: edit_detection
 
-    YASA does not currently support visual editing of the detected events. However, you can import the events as annotations in `EDFBrowser <https://www.teuniz.net/edfbrowser/>`_ and edit the events from there. If you simply want to visualize the detected events (no editing), you can also use the `plot_detection <https://raphaelvallat.com/yasa/build/html/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.plot_detection>`_ method.
+    YASA does not currently support visual editing of the detected events. However, you can import the events as annotations in `EDFBrowser <https://www.teuniz.net/edfbrowser/>`_ and edit the events from there. If you simply want to visualize the detected events (no editing), you can also use the `plot_detection <https://raphaelvallat.com/yasa/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.plot_detection>`_ method.
 
 
 .. ############################################################################

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -307,14 +307,14 @@ The exact same steps can be applied with the :py:func:`~yasa.sw_detect` function
 .. image:: https://raw.githubusercontent.com/raphaelvallat/yasa/refs/tags/v0.6.5/docs/pictures/quickstart/avg_sw.png
   :align: center
 
-For more details on the output of the slow-waves detection, be sure to read the `documentation <https://raphaelvallat.com/yasa/generated/yasa.sw_detect.html>`_ and try the `Jupyter notebooks <https://github.com/raphaelvallat/yasa/tree/master/notebooks>`_.
+For more details on the output of the slow-waves detection, be sure to read the `documentation <https://raphaelvallat.github.io/yasa/generated/yasa.sw_detect.html>`_ and try the `Jupyter notebooks <https://github.com/raphaelvallat/yasa/tree/master/notebooks>`_.
 
 ********
 
 Automatic sleep staging
 -----------------------
 
-In this final section, we'll see how to perform automatic sleep staging in YASA. As shown below, this takes no more than a few lines of code! Here, we'll use a single EEG channel to predict a full-night hypnogram. For more details on the algorithm, check out the `eLife publication <https://elifesciences.org/articles/70092>`_ or the `documentation <https://raphaelvallat.com/yasa/generated/yasa.SleepStaging.html#yasa.SleepStaging>`_ of the function.
+In this final section, we'll see how to perform automatic sleep staging in YASA. As shown below, this takes no more than a few lines of code! Here, we'll use a single EEG channel to predict a full-night hypnogram. For more details on the algorithm, check out the `eLife publication <https://elifesciences.org/articles/70092>`_ or the `documentation <https://raphaelvallat.github.io/yasa/generated/yasa.SleepStaging.html#yasa.SleepStaging>`_ of the function.
 
 .. code-block:: python
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -307,14 +307,14 @@ The exact same steps can be applied with the :py:func:`~yasa.sw_detect` function
 .. image:: https://raw.githubusercontent.com/raphaelvallat/yasa/refs/tags/v0.6.5/docs/pictures/quickstart/avg_sw.png
   :align: center
 
-For more details on the output of the slow-waves detection, be sure to read the `documentation <https://raphaelvallat.com/yasa/build/html/generated/yasa.sw_detect.html>`_ and try the `Jupyter notebooks <https://github.com/raphaelvallat/yasa/tree/master/notebooks>`_.
+For more details on the output of the slow-waves detection, be sure to read the `documentation <https://raphaelvallat.com/yasa/generated/yasa.sw_detect.html>`_ and try the `Jupyter notebooks <https://github.com/raphaelvallat/yasa/tree/master/notebooks>`_.
 
 ********
 
 Automatic sleep staging
 -----------------------
 
-In this final section, we'll see how to perform automatic sleep staging in YASA. As shown below, this takes no more than a few lines of code! Here, we'll use a single EEG channel to predict a full-night hypnogram. For more details on the algorithm, check out the `eLife publication <https://elifesciences.org/articles/70092>`_ or the `documentation <https://raphaelvallat.com/yasa/build/html/generated/yasa.SleepStaging.html#yasa.SleepStaging>`_ of the function.
+In this final section, we'll see how to perform automatic sleep staging in YASA. As shown below, this takes no more than a few lines of code! Here, we'll use a single EEG channel to predict a full-night hypnogram. For more details on the algorithm, check out the `eLife publication <https://elifesciences.org/articles/70092>`_ or the `documentation <https://raphaelvallat.com/yasa/generated/yasa.SleepStaging.html#yasa.SleepStaging>`_ of the function.
 
 .. code-block:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ docs = [
     "sphinx-design>=0.6",
     "sphinx-copybutton>=0.5",
     "sphinx-notfound-page>=1",
+    "sphinx-reredirects>=0.1",
     "pydata-sphinx-theme>0.16",
     "numpydoc>=1.8",
 ]

--- a/src/yasa/features.py
+++ b/src/yasa/features.py
@@ -246,7 +246,7 @@ def compute_features_stage(
 
     # Detect spindles in N2 and N3
     # Thresholds have to be tuned with visual scoring of a subset of data
-    # https://raphaelvallat.com/yasa/build/html/generated/yasa.spindles_detect.html
+    # https://raphaelvallat.com/yasa/generated/yasa.spindles_detect.html
     sp = yasa.spindles_detect(raw_eeg, hypno=hypno, **spindles_params)
 
     df_sp = sp.summary(grp_chan=True, grp_stage=True).reset_index()

--- a/src/yasa/features.py
+++ b/src/yasa/features.py
@@ -246,7 +246,7 @@ def compute_features_stage(
 
     # Detect spindles in N2 and N3
     # Thresholds have to be tuned with visual scoring of a subset of data
-    # https://raphaelvallat.com/yasa/generated/yasa.spindles_detect.html
+    # https://raphaelvallat.github.io/yasa/generated/yasa.spindles_detect.html
     sp = yasa.spindles_detect(raw_eeg, hypno=hypno, **spindles_params)
 
     df_sp = sp.summary(grp_chan=True, grp_stage=True).reset_index()

--- a/src/yasa/staging.py
+++ b/src/yasa/staging.py
@@ -67,7 +67,7 @@ class SleepStaging:
     We provide below some key points on the algorithm and its validation. For more details,
     we refer the reader to the peer-reviewed publication. If you have any questions,
     make sure to first check the
-    `FAQ section <https://raphaelvallat.com/yasa/faq.html>`_ of the documentation.
+    `FAQ section <https://raphaelvallat.github.io/yasa/faq.html>`_ of the documentation.
     If you did not find the answer to your question, please feel free to open an issue on GitHub.
 
     **1. Features extraction**
@@ -159,7 +159,7 @@ class SleepStaging:
 
     The sleep scores can then be manually edited in an external graphical user interface
     (e.g. EDFBrowser), as described in the
-    `FAQ <https://raphaelvallat.com/yasa/faq.html>`_.
+    `FAQ <https://raphaelvallat.github.io/yasa/faq.html>`_.
     """
 
     def __init__(self, raw, eeg_name, *, eog_name=None, emg_name=None, metadata=None):

--- a/src/yasa/staging.py
+++ b/src/yasa/staging.py
@@ -67,7 +67,7 @@ class SleepStaging:
     We provide below some key points on the algorithm and its validation. For more details,
     we refer the reader to the peer-reviewed publication. If you have any questions,
     make sure to first check the
-    `FAQ section <https://raphaelvallat.com/yasa/build/html/faq.html>`_ of the documentation.
+    `FAQ section <https://raphaelvallat.com/yasa/faq.html>`_ of the documentation.
     If you did not find the answer to your question, please feel free to open an issue on GitHub.
 
     **1. Features extraction**
@@ -159,7 +159,7 @@ class SleepStaging:
 
     The sleep scores can then be manually edited in an external graphical user interface
     (e.g. EDFBrowser), as described in the
-    `FAQ <https://raphaelvallat.com/yasa/build/html/faq.html>`_.
+    `FAQ <https://raphaelvallat.com/yasa/faq.html>`_.
     """
 
     def __init__(self, raw, eeg_name, *, eog_name=None, emg_name=None, metadata=None):


### PR DESCRIPTION
Fixes the 404 page display, resolving #201 ~~in an effective but sub-optimal way~~. See that thread for details, but basically this provides a major relief by having a pretty 404 page that tells visitors how to fix their problem of having the out-dated link.

~~A better solution would be to _fix the problem for them_ with a systematic redirect to the page we think they want. We can consider that but the current PR provides a big upgrade from the currently busted 404 page.~~ _EDIT: Auto-redirecting prior links to appropriate new pages is not part of the current PR._

The 404 formatting problem was related to the sphinx `notfound.extension` configuration. Specifically [setting it up for GH pages](https://sphinx-notfound-page.readthedocs.io/en/latest/faq.html#does-this-extension-work-with-github-pages). _The broader issue of links breaking was because prior versions of the site had all files stored under `build/html` directories that were part of the URL, whereas new page does not._

I also updated some hard-coded links. I did not update the links in the notebooks, because updating notebooks can be cumbersome and I already have an open PR that adds major notebook changes, so I will update them their. The current PR sorta handles them anyways by giving the user a better landing page if they click them.

_I also set `html_baseurl` in sphinx config which should label the current pages as canonical links and help search engines prioritize that version of the site, hopefully winding down traffic to the old links._