### PR TITLE
Add volts vs micro-volts to FAQ

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -26,6 +26,18 @@ Loading and visualizing polysomnography data
         # Select a subset of EEG channels
         raw.pick(["C4-A1", "C3-A2"])
 
+.. ----------------------------- LOAD EDF -----------------------------
+.. dropdown:: Should my data be in Volts or micro-Volts?
+    :animate: fade-in-slide-down
+    :icon: question
+    :name: what_voltage
+
+    Where EEG data is concerned, YASA's algorithms are designed to work with data in units of micro-Volts.
+    When ``data`` is passed to a YASA function as a :py:class:`~numpy.ndarray`, the unit must be micro-Volts (uV).
+    For most functions, YASA allows the ``data`` parameter to be either a :py:class:`numpy.ndarray` or a :py:class:`mne.io.BaseRaw`.
+    Instances of :py:class:`~mne.io.BaseRaw` have unit information included in them, so in these cases, YASA will handle any
+    necessary conversions by extracting the data internally in the required units (using :py:meth:`~mne.io.BaseRaw.get_data`).
+
 .. ----------------------------- VISUALIZE -----------------------------
 .. dropdown:: Can I visualize my polysomnography data in YASA?
     :animate: fade-in-slide-down

--- a/src/yasa/detection.py
+++ b/src/yasa/detection.py
@@ -596,22 +596,20 @@ def spindles_detect(
 
     Parameters
     ----------
-    data : array_like
-        Single or multi-channel data. Unit must be uV and shape (n_samples) or
-        (n_chan, n_samples). Can also be a :py:class:`mne.io.BaseRaw`,
-        in which case ``data``, ``sf``, and ``ch_names`` will be automatically
-        extracted, and ``data`` will also be automatically converted from
-        Volts (MNE) to micro-Volts (YASA).
+    data : array_like or :py:class:`mne.io.BaseRaw`
+        Single or multi-channel data. If ``data`` is array_like, unit must be uV and of
+        shape (n_samples) or (n_chan, n_samples). If ``data`` is a :py:class:`~mne.io.BaseRaw`
+        instance, ``data``, ``sf``, and ``ch_names`` will be automatically extracted, and
+        ``data`` will be automatically converted from Volts (MNE) to micro-Volts (YASA).
     sf : float
         Sampling frequency of the data in Hz.
-        Can be omitted if ``data`` is a :py:class:`mne.io.BaseRaw`.
+        Can be omitted if ``data`` is a :py:class:`~mne.io.BaseRaw` instance.
 
         .. tip:: If the detection is taking too long, make sure to downsample
             your data to 100 Hz (or 128 Hz). For more details, please refer to
             :py:func:`mne.filter.resample`.
     ch_names : list of str
-        Channel names. Can be omitted if ``data`` is a
-        :py:class:`mne.io.BaseRaw`.
+        Channel names. Can be omitted if ``data`` is a :py:class:`~mne.io.BaseRaw` instance.
     hypno : array_like
         Sleep stage (hypnogram). If the hypnogram is loaded, the
         detection will only be applied to the value defined in
@@ -1416,22 +1414,20 @@ def sw_detect(
 
     Parameters
     ----------
-    data : array_like
-        Single or multi-channel data. Unit must be uV and shape (n_samples) or
-        (n_chan, n_samples). Can also be a :py:class:`mne.io.BaseRaw`,
-        in which case ``data``, ``sf``, and ``ch_names`` will be automatically
-        extracted, and ``data`` will also be automatically converted from
-        Volts (MNE) to micro-Volts (YASA).
+    data : array_like or :py:class:`mne.io.BaseRaw`
+        Single or multi-channel data. If ``data`` is array_like, unit must be uV and of
+        shape (n_samples) or (n_chan, n_samples). If ``data`` is a :py:class:`~mne.io.BaseRaw`
+        instance, ``data``, ``sf``, and ``ch_names`` will be automatically extracted, and
+        ``data`` will be automatically converted from Volts (MNE) to micro-Volts (YASA).
     sf : float
         Sampling frequency of the data in Hz.
-        Can be omitted if ``data`` is a :py:class:`mne.io.BaseRaw`.
+        Can be omitted if ``data`` is a :py:class:`~mne.io.BaseRaw` instance.
 
         .. tip:: If the detection is taking too long, make sure to downsample
             your data to 100 Hz (or 128 Hz). For more details, please refer to
             :py:func:`mne.filter.resample`.
     ch_names : list of str
-        Channel names. Can be omitted if ``data`` is a
-        :py:class:`mne.io.BaseRaw`.
+        Channel names. Can be omitted if ``data`` is a :py:class:`~mne.io.BaseRaw` instance.
     hypno : array_like
         Sleep stage (hypnogram). If the hypnogram is loaded, the
         detection will only be applied to the value defined in
@@ -2821,20 +2817,18 @@ def art_detect(
 
     Parameters
     ----------
-    data : array_like
-        Single or multi-channel EEG data.
-        Unit must be uV and shape *(n_chan, n_samples)*.
-        Can also be a :py:class:`mne.io.BaseRaw`, in which case ``data``
-        and ``sf`` will be automatically extracted,
-        and ``data`` will also be automatically converted from Volts (MNE)
-        to micro-Volts (YASA).
+    data : array_like or :py:class:`mne.io.BaseRaw`
+        Single or multi-channel EEG data. If ``data`` is array_like, unit must be uV and of
+        shape *(n_chan, n_samples)*. If ``data`` is a :py:class:`~mne.io.BaseRaw`
+        instance, ``data`` and ``sf`` will be automatically extracted, and
+        ``data`` will be automatically converted from Volts (MNE) to micro-Volts (YASA).
 
         .. warning::
             ``data`` must only contains EEG channels. Please make sure to
             exclude any EOG, EKG or EMG channels.
     sf : float
         Sampling frequency of the data in Hz.
-        Can be omitted if ``data`` is a :py:class:`mne.io.BaseRaw` object.
+        Can be omitted if ``data`` is a :py:class:`~mne.io.BaseRaw` instance.
     window : float
         The window length (= resolution) for artifact rejection, in seconds.
         Default to 5 seconds. Shorter windows (e.g. 1 or 2-seconds) will

--- a/src/yasa/spectral.py
+++ b/src/yasa/spectral.py
@@ -46,9 +46,10 @@ def bandpower(
     Parameters
     ----------
     data : np.array_like or :py:class:`mne.io.BaseRaw`
-        1D or 2D EEG data. Can also be a :py:class:`mne.io.BaseRaw`, in which case ``data``,
-        ``sf``, and ``ch_names`` will be automatically extracted, and ``data`` will also be
-        converted from Volts (MNE default) to micro-Volts (YASA).
+        1D or 2D EEG data. If ``data`` is array_like, unit must be uV.
+        If ``data`` is a :py:class:`~mne.io.BaseRaw` instance, ``data``, ``sf``, and
+        ``ch_names`` will be automatically extracted, and ``data`` will be automatically
+        converted from Volts (MNE) to micro-Volts (YASA).
     sf : float
         The sampling frequency of data AND the hypnogram. Can be omitted if ``data`` is a
         :py:class:`mne.io.BaseRaw`.
@@ -399,10 +400,10 @@ def irasa(
     Parameters
     ----------
     data : :py:class:`numpy.ndarray` or :py:class:`mne.io.BaseRaw`
-        1D or 2D EEG data. Can also be a :py:class:`mne.io.BaseRaw`, in which
-        case ``data``, ``sf``, and ``ch_names`` will be automatically
-        extracted, and ``data`` will also be converted from Volts (MNE default)
-        to micro-Volts (YASA).
+        1D or 2D EEG data. If ``data`` is array_like, unit must be uV.
+        If ``data`` is a :py:class:`~mne.io.BaseRaw` instance, ``data``, ``sf``, and
+        ``ch_names`` will be automatically extracted, and ``data`` will be automatically
+        converted from Volts (MNE) to micro-Volts (YASA).
     sf : float
         The sampling frequency of data AND the hypnogram.
         Can be omitted if ``data`` is a :py:class:`mne.io.BaseRaw`.

--- a/src/yasa/staging.py
+++ b/src/yasa/staging.py
@@ -40,8 +40,7 @@ class SleepStaging:
     eeg_name : str
         The name of the EEG channel in ``raw``. Preferentially a central
         electrode referenced either to the mastoids (C4-M1, C3-M2) or to the
-        Fpz electrode (C4-Fpz). Data are assumed to be in Volts (MNE default)
-        and will be converted to uV.
+        Fpz electrode (C4-Fpz).
     eog_name : str or None
         The name of the EOG channel in ``raw``. Preferentially,
         the left LOC channel referenced either to the mastoid (e.g. E1-M2)
@@ -88,12 +87,14 @@ class SleepStaging:
     In addition, the algorithm also calculates a smoothed and normalized version of these features.
     Specifically, a 7.5 min centered triangular-weighted rolling average and a 2 min past rolling
     average are applied. The resulting smoothed features are then normalized using a robust
-    z-score.
+    z-score. The algorithm assumes data are in micro-Volts.
 
-    .. important:: The PSG data should be in micro-Volts. Do NOT transform (e.g. z-score) or filter
-        the signal before running the sleep staging algorithm.
+    .. important:: Do NOT transform (e.g. z-score) or filter the signal before running
+        the sleep staging algorithm.
 
     The data are automatically downsampled to 100 Hz for faster computation.
+
+    The data are automatically converted to micro-Volts if necessary.
 
     **2. Sleep stages prediction**
 


### PR DESCRIPTION
This docs-only PR aims to clarify some of the V vs uV in the online documentation. I've been getting this question a lot lately, users aren't sure if they should be passing data as Volts or micro-Volts.

I agree with users it was particularly confusing on the `yasa.SleepStaging` page, where it said data assumed to be in V, but also that it must be in uV elsewhere. I think it was written with respect to the user in the format, and with respect to the algorithm in the latter. In any case, I made some minor edits for hopefuly clarity, and also consistency across functions that take similar parameters. Most importantly I added a FAQ.