### PR TITLE
Log warning when sf or ch_names are ignored

### DIFF
--- a/src/yasa/detection.py
+++ b/src/yasa/detection.py
@@ -54,6 +54,10 @@ def _check_data_hypno(data, sf=None, ch_names=None, hypno=None, include=None, ch
     """Helper functions for preprocessing of data and hypnogram."""
     # 1) Extract data as a 2D NumPy array
     if isinstance(data, mne.io.BaseRaw):
+        if sf is not None:
+            logger.warning("sf parameter will be ignored, sf from MNE Raw will be used")
+        if ch_names is not None:
+            logger.warning("ch_names parameter will be ignored, ch_names from MNE Raw will be used")
         sf = data.info["sfreq"]  # Extract sampling frequency
         ch_names = data.ch_names  # Extract channel names
         data = data.get_data(units=dict(eeg="uV", emg="uV", eog="uV", ecg="uV"))
@@ -597,19 +601,20 @@ def spindles_detect(
     Parameters
     ----------
     data : array_like or :py:class:`mne.io.BaseRaw`
-        Single or multi-channel data. If ``data`` is array_like, unit must be uV and of
+        Single or multi-channel data. If ``data`` is *array_like*, unit must be uV and of
         shape (n_samples) or (n_chan, n_samples). If ``data`` is a :py:class:`~mne.io.BaseRaw`
         instance, ``data``, ``sf``, and ``ch_names`` will be automatically extracted, and
         ``data`` will be automatically converted from Volts (MNE) to micro-Volts (YASA).
     sf : float
-        Sampling frequency of the data in Hz.
-        Can be omitted if ``data`` is a :py:class:`~mne.io.BaseRaw` instance.
+        Sampling frequency of the data in Hz when ``data`` is *array_like*.
+        Should be omitted if ``data`` is a :py:class:`~mne.io.BaseRaw` instance.
 
         .. tip:: If the detection is taking too long, make sure to downsample
             your data to 100 Hz (or 128 Hz). For more details, please refer to
             :py:func:`mne.filter.resample`.
     ch_names : list of str
-        Channel names. Can be omitted if ``data`` is a :py:class:`~mne.io.BaseRaw` instance.
+        Channel names if ``data`` is *array_like*.
+        Should be omitted if ``data`` is a :py:class:`~mne.io.BaseRaw` instance.
     hypno : array_like
         Sleep stage (hypnogram). If the hypnogram is loaded, the
         detection will only be applied to the value defined in
@@ -1415,19 +1420,20 @@ def sw_detect(
     Parameters
     ----------
     data : array_like or :py:class:`mne.io.BaseRaw`
-        Single or multi-channel data. If ``data`` is array_like, unit must be uV and of
+        Single or multi-channel data. If ``data`` is *array_like*, unit must be uV and of
         shape (n_samples) or (n_chan, n_samples). If ``data`` is a :py:class:`~mne.io.BaseRaw`
         instance, ``data``, ``sf``, and ``ch_names`` will be automatically extracted, and
         ``data`` will be automatically converted from Volts (MNE) to micro-Volts (YASA).
     sf : float
-        Sampling frequency of the data in Hz.
-        Can be omitted if ``data`` is a :py:class:`~mne.io.BaseRaw` instance.
+        Sampling frequency of the data in Hz if ``data`` is *array_like*.
+        Should be omitted if ``data`` is a :py:class:`~mne.io.BaseRaw` instance.
 
         .. tip:: If the detection is taking too long, make sure to downsample
             your data to 100 Hz (or 128 Hz). For more details, please refer to
             :py:func:`mne.filter.resample`.
     ch_names : list of str
-        Channel names. Can be omitted if ``data`` is a :py:class:`~mne.io.BaseRaw` instance.
+        Channel names if ``data`` is *array_like*.
+        Should be omitted if ``data`` is a :py:class:`~mne.io.BaseRaw` instance.
     hypno : array_like
         Sleep stage (hypnogram). If the hypnogram is loaded, the
         detection will only be applied to the value defined in

--- a/src/yasa/spectral.py
+++ b/src/yasa/spectral.py
@@ -45,17 +45,18 @@ def bandpower(
 
     Parameters
     ----------
-    data : np.array_like or :py:class:`mne.io.BaseRaw`
-        1D or 2D EEG data. If ``data`` is array_like, unit must be uV.
+    data : array_like or :py:class:`mne.io.BaseRaw`
+        1D or 2D EEG data. If ``data`` is *array_like*, unit must be uV.
         If ``data`` is a :py:class:`~mne.io.BaseRaw` instance, ``data``, ``sf``, and
         ``ch_names`` will be automatically extracted, and ``data`` will be automatically
         converted from Volts (MNE) to micro-Volts (YASA).
     sf : float
-        The sampling frequency of data AND the hypnogram. Can be omitted if ``data`` is a
-        :py:class:`mne.io.BaseRaw`.
+        The sampling frequency of data AND the hypnogram if ``data`` is *array_like*.
+        Should be omitted if ``data`` is a :py:class:`~mne.io.BaseRaw`.
     ch_names : list
-        List of channel names, e.g. ['Cz', 'F3', 'F4', ...]. If None, channels will be labelled
-        ['CHAN000', 'CHAN001', ...]. Can be omitted if ``data`` is a :py:class:`mne.io.BaseRaw`.
+        List of channel names, e.g. ['Cz', 'F3', 'F4', ...], if ``data`` is *array_like*.
+        If None, channels will be labelled ['CHAN000', 'CHAN001', ...].
+        Should be omitted if ``data`` is a :py:class:`~mne.io.BaseRaw`.
     hypno : array_like
         Sleep stage (hypnogram). If the hypnogram is loaded, the bandpower will be extracted for
         each sleep stage defined in ``include``.
@@ -400,17 +401,17 @@ def irasa(
     Parameters
     ----------
     data : :py:class:`numpy.ndarray` or :py:class:`mne.io.BaseRaw`
-        1D or 2D EEG data. If ``data`` is array_like, unit must be uV.
+        1D or 2D EEG data. If ``data`` is *array_like*, unit must be uV.
         If ``data`` is a :py:class:`~mne.io.BaseRaw` instance, ``data``, ``sf``, and
         ``ch_names`` will be automatically extracted, and ``data`` will be automatically
         converted from Volts (MNE) to micro-Volts (YASA).
     sf : float
-        The sampling frequency of data AND the hypnogram.
-        Can be omitted if ``data`` is a :py:class:`mne.io.BaseRaw`.
+        The sampling frequency of data AND the hypnogram if ``data`` is *array_like*.
+        Should be omitted if ``data`` is a :py:class:~`mne.io.BaseRaw`.
     ch_names : list
-        List of channel names, e.g. ['Cz', 'F3', 'F4', ...]. If None,
-        channels will be labelled ['CHAN000', 'CHAN001', ...].
-        Can be omitted if ``data`` is a :py:class:`mne.io.BaseRaw`.
+        List of channel names, e.g. ['Cz', 'F3', 'F4', ...], if ``data`` is *array_like*.
+        If None, channels will be labelled ['CHAN000', 'CHAN001', ...].
+        Should be omitted if ``data`` is a :py:class:`~mne.io.BaseRaw`.
     band : tuple or None
         Broad band frequency range.
         Default is 1 to 30 Hz.

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -10,7 +10,14 @@ import pandas as pd
 import pytest
 from mne.filter import filter_data
 
-from yasa.detection import art_detect, compare_detection, rem_detect, spindles_detect, sw_detect
+from yasa.detection import (
+    _check_data_hypno,
+    art_detect,
+    compare_detection,
+    rem_detect,
+    spindles_detect,
+    sw_detect,
+)
 from yasa.fetchers import fetch_sample
 from yasa.hypno import hypno_str_to_int, hypno_upsample_to_data
 
@@ -62,7 +69,10 @@ class TestDetection(unittest.TestCase):
 
     def test_check_data_hypno(self):
         """Test preprocessing of data and hypno."""
-        pass
+        with self.assertLogs("yasa", level="WARNING"):
+            _check_data_hypno(data_mne, sf=999)  # sf is ignored
+        with self.assertLogs("yasa", level="WARNING"):
+            _check_data_hypno(data_mne, ch_names=["CH999"])  # ch_names is ignored
 
     def test_spindles_detect(self):
         """Test spindles_detect"""


### PR DESCRIPTION
This minor PR adds clarification surrounding a question in #156 about the `ch_names` parameter. I'm just implementing direct suggestions from there to provide clarity for the user:

1. Add clarification in the docstrings
2. Add a user warning when arguments are provided by user but ignored by YASA

Raising an AssertionError instead of a warning might make more sense, as assertion checks are used in the opposite case a few lines later (i.e., when ``data`` is specified and ``sf`` is not). But I didn't want to break anyone's existing code in case they passed sf through for logistical reasons or something. Happy to change if anyone prefers it as a raised error.
