### PR TITLE
yasa-sleep.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@
 * Spectral analyses: bandpower, phase-amplitude coupling, 1/f slope, and more!
 * Hypnogram analysis: sleep statistics and stage transitions.
 
-For more details, try the `quickstart <https://raphaelvallat.github.io/yasa/quickstart.html>`_ or read the `FAQ <https://raphaelvallat.github.io/yasa/faq.html>`_.
+For more details, try the `quickstart <https://yasa-sleep.org/quickstart.html>`_ or read the `FAQ <https://yasa-sleep.org/faq.html>`_.
 
 ----------------
 
@@ -88,7 +88,7 @@ If you have sleep EEG data in standard formats (e.g. EDF or BrainVision), you ca
 How do I get started with YASA?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want to dive right in, you can simply go to the main `documentation <https://raphaelvallat.github.io/yasa/quickstart.html>`_ and try to apply YASA's functions on your own EEG data.
+If you want to dive right in, you can simply go to the main `documentation <https://yasa-sleep.org/quickstart.html>`_ and try to apply YASA's functions on your own EEG data.
 However, for most users, we strongly recommend that you first try running the examples Jupyter notebooks to get a sense of how YASA works and what it can do!
 The notebooks also come with example datasets so they should work right out of the box as long as you've installed YASA first.
 The notebooks and datasets can be found on `GitHub <https://github.com/raphaelvallat/yasa/tree/master/notebooks>`_ (make sure that you download the whole *notebooks/* folder). A short description of all notebooks is provided below:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -208,7 +208,7 @@ Artefact and Unscored epochs are now excluded from the calculation of the total 
 
 **New FAQ**
 
-The online documentation now has a brand new FAQ section! Make sure to check it out at https://raphaelvallat.github.io/yasa/faq.html
+The online documentation now has a brand new FAQ section! Make sure to check it out at https://yasa-sleep.org/faq.html
 
 **New function: coincidence matrix**
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -316,7 +316,7 @@ html_theme_options = {
     "show_version_warning_banner": True,
 
     # Defaults to ""
-    # "announcement": "&#128680; This is documentation for the <b>unstable development version</b> of YASA. <a href='https://raphaelvallat.com/yasa'>Switch to stable version</a> &#128680;",
+    # "announcement": "&#128680; This is documentation for the <b>unstable development version</b> of YASA. <a href='https://yasa-sleep.org'>Switch to stable version</a> &#128680;",
     # "announcement": "<span style='font-family: Consolas, monospace;'>pip install yasa --upgrade</span> &#127881;",
 }
 
@@ -326,7 +326,7 @@ html_theme_options = {
 # The base URL which points to the root of the HTML documentation.
 # It is used to indicate the location of document using the Canonical Link Relation.
 # Defaults to ""
-html_baseurl = "https://raphaelvallat.com/yasa"
+html_baseurl = "https://yasa-sleep.org"
 
 # A dictionary of values to pass into the template engine's context for all pages.
 # Defaults to {}
@@ -695,7 +695,7 @@ notfound_context = {
 # Defaults to READTHEDOCS env variable, typically "/en/latest/"
 # Note special case when using default GitHub pages URL: "/<repo>/"
 # https://sphinx-notfound-page.readthedocs.io/en/latest/faq.html#does-this-extension-work-with-github-pages
-notfound_urls_prefix = "/yasa/"
+notfound_urls_prefix = None
 
 # -- External extensions -----------------------------------------------------
 # -- -> Options for sphinx_reredirects -------------------------------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -98,7 +98,7 @@ Event detection
     :icon: question
     :name: edit_detection
 
-    YASA does not currently support visual editing of the detected events. However, you can import the events as annotations in `EDFBrowser <https://www.teuniz.net/edfbrowser/>`_ and edit the events from there. If you simply want to visualize the detected events (no editing), you can also use the `plot_detection <https://raphaelvallat.github.io/yasa/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.plot_detection>`_ method.
+    YASA does not currently support visual editing of the detected events. However, you can import the events as annotations in `EDFBrowser <https://www.teuniz.net/edfbrowser/>`_ and edit the events from there. If you simply want to visualize the detected events (no editing), you can also use the `plot_detection <https://yasa-sleep.org/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.plot_detection>`_ method.
 
 
 .. ############################################################################
@@ -226,7 +226,7 @@ Others
 
         pip install --upgrade yasa
         pip install --upgrade yasa
-    
+
 
 .. ----------------------------- DEVELOPMENT -----------------------------
 .. raw:: html

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -307,14 +307,14 @@ The exact same steps can be applied with the :py:func:`~yasa.sw_detect` function
 .. image:: https://raw.githubusercontent.com/raphaelvallat/yasa/refs/tags/v0.6.5/docs/pictures/quickstart/avg_sw.png
   :align: center
 
-For more details on the output of the slow-waves detection, be sure to read the `documentation <https://raphaelvallat.github.io/yasa/generated/yasa.sw_detect.html>`_ and try the `Jupyter notebooks <https://github.com/raphaelvallat/yasa/tree/master/notebooks>`_.
+For more details on the output of the slow-waves detection, be sure to read the `documentation <https://yasa-sleep.org/generated/yasa.sw_detect.html>`_ and try the `Jupyter notebooks <https://github.com/raphaelvallat/yasa/tree/master/notebooks>`_.
 
 ********
 
 Automatic sleep staging
 -----------------------
 
-In this final section, we'll see how to perform automatic sleep staging in YASA. As shown below, this takes no more than a few lines of code! Here, we'll use a single EEG channel to predict a full-night hypnogram. For more details on the algorithm, check out the `eLife publication <https://elifesciences.org/articles/70092>`_ or the `documentation <https://raphaelvallat.github.io/yasa/generated/yasa.SleepStaging.html#yasa.SleepStaging>`_ of the function.
+In this final section, we'll see how to perform automatic sleep staging in YASA. As shown below, this takes no more than a few lines of code! Here, we'll use a single EEG channel to predict a full-night hypnogram. For more details on the algorithm, check out the `eLife publication <https://elifesciences.org/articles/70092>`_ or the `documentation <https://yasa-sleep.org/generated/yasa.SleepStaging.html#yasa.SleepStaging>`_ of the function.
 
 .. code-block:: python
 

--- a/notebooks/01_spindles_detection.ipynb
+++ b/notebooks/01_spindles_detection.ipynb
@@ -80,7 +80,7 @@
    "source": [
     "We can clearly see that there are two clean spindles on this 15-seconds epoch. The first one starting at around 3.5 seconds and the second one starting around 13 seconds.\n",
     "\n",
-    "Let's try to detect these two spindles using the [yasa.spindles_detect](https://raphaelvallat.github.io/yasa/build/html/generated/yasa.spindles_detect.html) function. Here' we're using a minimal example, but there are many other optional arguments that you can pass to this function."
+    "Let's try to detect these two spindles using the [yasa.spindles_detect](https://yasa-sleep.org/build/html/generated/yasa.spindles_detect.html) function. Here' we're using a minimal example, but there are many other optional arguments that you can pass to this function."
    ]
   },
   {
@@ -190,7 +190,7 @@
    "source": [
     "Hooray! The algorithm successfully identified the two spindles! \n",
     "\n",
-    "The output of the spindles detection is a [SpindlesResults](https://raphaelvallat.github.io/yasa/build/html/generated/yasa.SpindlesResults.html#yasa.SpindlesResults) class, which comes with some pre-compiled functions (also called methods). For instance, the [summary](https://raphaelvallat.github.io/yasa/build/html/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.summary) method returns a [pandas DataFrame](http://pandas.pydata.org/pandas-docs/stable/dsintro.html#dataframe) with all the detected spindles and their properties."
+    "The output of the spindles detection is a [SpindlesResults](https://yasa-sleep.org/build/html/generated/yasa.SpindlesResults.html#yasa.SpindlesResults) class, which comes with some pre-compiled functions (also called methods). For instance, the [summary](https://yasa-sleep.org/build/html/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.summary) method returns a [pandas DataFrame](http://pandas.pydata.org/pandas-docs/stable/dsintro.html#dataframe) with all the detected spindles and their properties."
    ]
   },
   {
@@ -199,7 +199,7 @@
    "source": [
     "### Plot an overlay of our detected spindles\n",
     "\n",
-    "First we need to create a boolean array of the same size of data indicating for each sample if this sample is part of a spindles or not. This is done using the [get_mask](https://raphaelvallat.github.io/yasa/build/html/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.get_mask) method:"
+    "First we need to create a boolean array of the same size of data indicating for each sample if this sample is part of a spindles or not. This is done using the [get_mask](https://yasa-sleep.org/build/html/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.get_mask) method:"
    ]
   },
   {

--- a/notebooks/02_spindles_detection_multi.ipynb
+++ b/notebooks/02_spindles_detection_multi.ipynb
@@ -63,7 +63,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To apply the multi-channel detection, we use the [spindles_detect](https://raphaelvallat.github.io/yasa/build/html/generated/yasa.spindles_detect.html#yasa.spindles_detect) function:"
+    "To apply the multi-channel detection, we use the [spindles_detect](https://yasa-sleep.org/build/html/generated/yasa.spindles_detect.html#yasa.spindles_detect) function:"
    ]
   },
   {
@@ -337,7 +337,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using the [summary](https://raphaelvallat.github.io/yasa/build/html/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.summary) method, we can easily extract the number of spindles detected per channel, as well as the mean spindles properties per channel:"
+    "Using the [summary](https://yasa-sleep.org/build/html/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.summary) method, we can easily extract the number of spindles detected per channel, as well as the mean spindles properties per channel:"
    ]
   },
   {
@@ -474,7 +474,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, we can also plot an average template of all detected spindles with the [plot_average](https://raphaelvallat.github.io/yasa/build/html/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.plot_average) method:"
+    "Finally, we can also plot an average template of all detected spindles with the [plot_average](https://yasa-sleep.org/build/html/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.plot_average) method:"
    ]
   },
   {
@@ -504,7 +504,7 @@
    "source": [
     "### Check the agreement between channels\n",
     "\n",
-    "Do the detected events overlap across channels? We can test this with the [compare_channels](https://raphaelvallat.github.io/yasa/build/html/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.compare_channels) method. In the example below, we calculate the [recall score](https://en.wikipedia.org/wiki/Precision_and_recall) between each pair of channels. To allow for slight variations in the onset of the spindle, we allow a tolerance of 0.5 seconds before and after the onset of each spindle."
+    "Do the detected events overlap across channels? We can test this with the [compare_channels](https://yasa-sleep.org/build/html/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.compare_channels) method. In the example below, we calculate the [recall score](https://en.wikipedia.org/wiki/Precision_and_recall) between each pair of channels. To allow for slight variations in the onset of the spindle, we allow a tolerance of 0.5 seconds before and after the onset of each spindle."
    ]
   },
   {
@@ -957,7 +957,7 @@
    "source": [
     "### Compare two detections\n",
     "\n",
-    "What is the agreement between the regular detection and the detection after automatic outlier removal? To check this, we can use the [compare_detection](https://raphaelvallat.github.io/yasa/build/html/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.compare_detection) method, which will calculate the [precision, recall and F1-score](https://en.wikipedia.org/wiki/Precision_and_recall) of the two detections for each channel. Note that by default, the other detection is assumed to be the ground-truth. This method is also useful if you want to compare YASA detection against ground-truth human annotations. Here again, we can allow for slight variations in the onset of the spindle by defining a tolerance period before and after the onset of each spindle."
+    "What is the agreement between the regular detection and the detection after automatic outlier removal? To check this, we can use the [compare_detection](https://yasa-sleep.org/build/html/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.compare_detection) method, which will calculate the [precision, recall and F1-score](https://en.wikipedia.org/wiki/Precision_and_recall) of the two detections for each channel. Note that by default, the other detection is assumed to be the ground-truth. This method is also useful if you want to compare YASA detection against ground-truth human annotations. Here again, we can allow for slight variations in the onset of the spindle by defining a tolerance period before and after the onset of each spindle."
    ]
   },
   {
@@ -2219,7 +2219,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To get the actual peak-locked data underlying this figure, one can use the [get_sync_events](https://raphaelvallat.github.io/yasa/build/html/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.get_sync_events) method. The output is a long-format dataframe with the original data values centered around each detected spindles."
+    "To get the actual peak-locked data underlying this figure, one can use the [get_sync_events](https://yasa-sleep.org/build/html/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.get_sync_events) method. The output is a long-format dataframe with the original data values centered around each detected spindles."
    ]
   },
   {

--- a/notebooks/03_spindles_detection_NREM_only.ipynb
+++ b/notebooks/03_spindles_detection_NREM_only.ipynb
@@ -57,7 +57,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we load the sleep staging vector (a.k.a hypnogram), which is a simple text file in which each value typically represents 30 seconds of data. Sleep stages are encoded as integer (*0: Wake, 1: N1 sleep, 2: N2 sleep, 3: N3 sleep, 4: REM sleep*). In the code below, we load our 30-sec hypnogram and upsample it to match the sampling frequency and length of data, using YASA's built-in [hypno_upsample_to_data](https://raphaelvallat.github.io/yasa/generated/yasa.hypno_upsample_to_data.html#yasa.hypno_upsample_to_data) function. Please refer to [08_bandpower.ipynb](08_bandpower.ipynb) for more details on how to manipulate hypnogram in YASA."
+    "Next, we load the sleep staging vector (a.k.a hypnogram), which is a simple text file in which each value typically represents 30 seconds of data. Sleep stages are encoded as integer (*0: Wake, 1: N1 sleep, 2: N2 sleep, 3: N3 sleep, 4: REM sleep*). In the code below, we load our 30-sec hypnogram and upsample it to match the sampling frequency and length of data, using YASA's built-in [hypno_upsample_to_data](https://yasa-sleep.org/generated/yasa.hypno_upsample_to_data.html#yasa.hypno_upsample_to_data) function. Please refer to [08_bandpower.ipynb](08_bandpower.ipynb) for more details on how to manipulate hypnogram in YASA."
    ]
   },
   {
@@ -91,7 +91,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To have a quick overview of our data, we can use [yasa.plot_spectrogram](https://raphaelvallat.github.io/yasa/generated/yasa.plot_spectrogram.html) function. Please check out [10_spectrogram.ipynb](10_spectrogram.ipynb) for a walkthrough of this function."
+    "To have a quick overview of our data, we can use [yasa.plot_spectrogram](https://yasa-sleep.org/generated/yasa.plot_spectrogram.html) function. Please check out [10_spectrogram.ipynb](10_spectrogram.ipynb) for a walkthrough of this function."
    ]
   },
   {
@@ -128,7 +128,7 @@
    "source": [
     "## 2. Apply the sleep spindles detection\n",
     "\n",
-    "To apply the multi-channel detection, we use the [yasa.spindles_detect](https://raphaelvallat.github.io/yasa/generated/yasa.spindles_detect.html) function. We also pass the hypnogram to restrain the detection to specific sleep stages, which are defined as integers in the ``include`` argument. Below, we're limiting the detection to NREM sleep, i.e. N1 (=1), N2 (=2) and N3 (=3) sleep."
+    "To apply the multi-channel detection, we use the [yasa.spindles_detect](https://yasa-sleep.org/generated/yasa.spindles_detect.html) function. We also pass the hypnogram to restrain the detection to specific sleep stages, which are defined as integers in the ``include`` argument. Below, we're limiting the detection to NREM sleep, i.e. N1 (=1), N2 (=2) and N3 (=3) sleep."
    ]
   },
   {
@@ -412,7 +412,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using the [summary](https://raphaelvallat.github.io/yasa/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.summary) method, we can easily get the spindles parameters, averaged across channel and sleep stage. The ``Density`` column is the number of spindles per minutes of each stage. For example, in the first row (Stage = 1, Channel = Cz), a density of 2.0 means that there are 2 spindles per minutes of N1 sleep detected on Cz."
+    "Using the [summary](https://yasa-sleep.org/generated/yasa.SpindlesResults.html#yasa.SpindlesResults.summary) method, we can easily get the spindles parameters, averaged across channel and sleep stage. The ``Density`` column is the number of spindles per minutes of each stage. For example, in the first row (Stage = 1, Channel = Cz), a density of 2.0 means that there are 2 spindles per minutes of N1 sleep detected on Cz."
    ]
   },
   {

--- a/notebooks/04_spindles_slow_fast.ipynb
+++ b/notebooks/04_spindles_slow_fast.ipynb
@@ -76,7 +76,7 @@
    "source": [
     "Next, we load the sleep staging vector (a.k.a hypnogram), which is a simple text file in which each value represents 30 seconds of data. Sleep stages are encoded as integer (*0: Wake, 1: N1 sleep, 2: N2 sleep, 3: N3 sleep, 4: REM sleep*).\n",
     "\n",
-    "In the code below, we load our 30-sec hypnogram and upsample it to match the sampling frequency and length of data, using YASA's built-in [hypno_upsample_to_data](https://raphaelvallat.github.io/yasa/generated/yasa.hypno_upsample_to_data.html#yasa.hypno_upsample_to_data) function.\n",
+    "In the code below, we load our 30-sec hypnogram and upsample it to match the sampling frequency and length of data, using YASA's built-in [hypno_upsample_to_data](https://yasa-sleep.org/generated/yasa.hypno_upsample_to_data.html#yasa.hypno_upsample_to_data) function.\n",
     "\n",
     "Please refer to [08_bandpower.ipynb](08_bandpower.ipynb) for more details on how to manipulate hypnogram in YASA."
    ]

--- a/notebooks/05_sw_detection.ipynb
+++ b/notebooks/05_sw_detection.ipynb
@@ -87,7 +87,7 @@
    "source": [
     "## Apply the detection using absolute thresholds (default)\n",
     "\n",
-    "We use the [yasa.sw_detect](https://raphaelvallat.github.io/yasa/generated/yasa.sw_detect.html#yasa.sw_detect) function to apply the detection. The different input and output parameters are described in the [documentation of the function](https://raphaelvallat.github.io/yasa/generated/yasa.sw_detect.html#yasa.sw_detect).\n",
+    "We use the [yasa.sw_detect](https://yasa-sleep.org/generated/yasa.sw_detect.html#yasa.sw_detect) function to apply the detection. The different input and output parameters are described in the [documentation of the function](https://yasa-sleep.org/generated/yasa.sw_detect.html#yasa.sw_detect).\n",
     "\n",
     "**Note**: as explained below, you can also use relative amplitude thresholds (e.g. z-score or percentiles) instead of absolute physical thresholds (in uV)."
    ]
@@ -380,7 +380,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The output of the slow-waves detection is a [SWResults](https://raphaelvallat.github.io/yasa/generated/yasa.SWResults.html#yasa.SWResults) class, which comes with some pre-compiled functions (also called methods). For instance, the [summary](https://raphaelvallat.github.io/yasa/generated/yasa.SWResults.html#yasa.SWResults.summary) method returns a [pandas DataFrame](http://pandas.pydata.org/pandas-docs/stable/dsintro.html#dataframe) with all the detected slow-waves and their properties. The different slow-waves properties are explained in the figure below:\n",
+    "The output of the slow-waves detection is a [SWResults](https://yasa-sleep.org/generated/yasa.SWResults.html#yasa.SWResults) class, which comes with some pre-compiled functions (also called methods). For instance, the [summary](https://yasa-sleep.org/generated/yasa.SWResults.html#yasa.SWResults.summary) method returns a [pandas DataFrame](http://pandas.pydata.org/pandas-docs/stable/dsintro.html#dataframe) with all the detected slow-waves and their properties. The different slow-waves properties are explained in the figure below:\n",
     "\n",
     "<img src=\"https://raw.githubusercontent.com/raphaelvallat/yasa/master/docs/pictures/slow_waves.png\" alt=\"slow-waves\" style=\"width: 600px;\"/>"
    ]
@@ -389,7 +389,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using the ``grp_chan`` argument of the [summary](https://raphaelvallat.github.io/yasa/generated/yasa.SWResults.html#yasa.SWResults.summary) method, we can also easily get the average parameters of all detected slow-waves:"
+    "Using the ``grp_chan`` argument of the [summary](https://yasa-sleep.org/generated/yasa.SWResults.html#yasa.SWResults.summary) method, we can also easily get the average parameters of all detected slow-waves:"
    ]
   },
   {
@@ -477,7 +477,7 @@
    "source": [
     "### Plot the detected slow-waves\n",
     "\n",
-    "First we need to create a boolean array of the same size of data indicating for each sample if this sample is part of a spindles or not. This is done using the [get_mask](https://raphaelvallat.github.io/yasa/generated/yasa.SWResults.html#yasa.SWResults.get_mask) method"
+    "First we need to create a boolean array of the same size of data indicating for each sample if this sample is part of a spindles or not. This is done using the [get_mask](https://yasa-sleep.org/generated/yasa.SWResults.html#yasa.SWResults.get_mask) method"
    ]
   },
   {
@@ -608,7 +608,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, we can plot an average template of all detected slow-waves with the [plot_average](https://raphaelvallat.github.io/yasa/generated/yasa.SWResults.html#yasa.SWResults.plot_average) method:"
+    "Finally, we can plot an average template of all detected slow-waves with the [plot_average](https://yasa-sleep.org/generated/yasa.SWResults.html#yasa.SWResults.plot_average) method:"
    ]
   },
   {

--- a/notebooks/06_sw_detection_multi.ipynb
+++ b/notebooks/06_sw_detection_multi.ipynb
@@ -62,7 +62,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To apply the multi-channel detection, we use the [sw_detect](https://raphaelvallat.github.io/yasa/generated/yasa.spindles_detect.html#yasa.spindles_detect) function. Note that we pass the hypnogram and restrain the detection to N2 or N3 sleep."
+    "To apply the multi-channel detection, we use the [sw_detect](https://yasa-sleep.org/generated/yasa.spindles_detect.html#yasa.spindles_detect) function. Note that we pass the hypnogram and restrain the detection to N2 or N3 sleep."
    ]
   },
   {

--- a/notebooks/07_REMs_detection.ipynb
+++ b/notebooks/07_REMs_detection.ipynb
@@ -84,7 +84,7 @@
    "source": [
     "## Apply the detection\n",
     "\n",
-    "We use the [rem_detect](https://raphaelvallat.github.io/yasa/generated/yasa.rem_detect.html#yasa.rem_detect) function to apply the detection. The output of the detection is a [REMResults](https://raphaelvallat.github.io/yasa/generated/yasa.REMResults.html#yasa.REMResults) class, which comes with some pre-compiled functions (also called methods). For instance, the [summary](https://raphaelvallat.github.io/yasa/generated/yasa.REMResults.html#yasa.REMResults.summary) method returns a [pandas DataFrame](http://pandas.pydata.org/pandas-docs/stable/dsintro.html#dataframe) with all the detected REMs and their properties.\n",
+    "We use the [rem_detect](https://yasa-sleep.org/generated/yasa.rem_detect.html#yasa.rem_detect) function to apply the detection. The output of the detection is a [REMResults](https://yasa-sleep.org/generated/yasa.REMResults.html#yasa.REMResults) class, which comes with some pre-compiled functions (also called methods). For instance, the [summary](https://yasa-sleep.org/generated/yasa.REMResults.html#yasa.REMResults.summary) method returns a [pandas DataFrame](http://pandas.pydata.org/pandas-docs/stable/dsintro.html#dataframe) with all the detected REMs and their properties.\n",
     "\n",
     "The algorithm is based on an amplitude thresholding of the negative product of the LOC and ROC filtered signal. As such, this function requires BOTH the LOC and ROC EOG data, it does NOT work with a single EOG."
    ]

--- a/notebooks/08_bandpower.ipynb
+++ b/notebooks/08_bandpower.ipynb
@@ -152,7 +152,7 @@
     "    N3 => 3\n",
     "    R  => 4\n",
     "    \n",
-    "However, you can also apply a custom mapping using the `mapping_dict=` argument of the [hypno_str_to_int](https://raphaelvallat.github.io/yasa/generated/yasa.hypno_str_to_int.html#yasa.hypno_str_to_int) function."
+    "However, you can also apply a custom mapping using the `mapping_dict=` argument of the [hypno_str_to_int](https://yasa-sleep.org/generated/yasa.hypno_str_to_int.html#yasa.hypno_str_to_int) function."
    ]
   },
   {
@@ -193,7 +193,7 @@
    "source": [
     "The last step is to upsample our hypnogram to the sampling frequency of the data. This step is *absolutely critical* and all YASA's function require that the data and hypnogram have the same sampling frequency and shape -- which makes life so much easier to mask and select specific sleep stages.\n",
     "\n",
-    "Fortunately, YASA also provides a convenient function ([hypno_upsample_to_data](https://raphaelvallat.github.io/yasa/generated/yasa.hypno_upsample_to_data.html#yasa.hypno_upsample_to_data)) to automatically upsample and fit the hypnogram to a given sampling frequency and data length.\n",
+    "Fortunately, YASA also provides a convenient function ([hypno_upsample_to_data](https://yasa-sleep.org/generated/yasa.hypno_upsample_to_data.html#yasa.hypno_upsample_to_data)) to automatically upsample and fit the hypnogram to a given sampling frequency and data length.\n",
     "This function requires the hypnogram and its sampling frequency, as well as the data and its sampling frequency. In our case, the sampling frequency of our hypnogram is 1 / 30 since there is one point per every 30 seconds of data. The sampling frequency of the data is 100 Hz.\n",
     "\n",
     "Note that if the upsampled hypnogram is shorter or longer than the length of data, a warning will be displayed and the hypnogram will be automatically padded or cropped to exactly match the length of data."
@@ -325,7 +325,7 @@
     "\n",
     "Now that we have the PSD for each channel, we need to calculate the average power in specified bands. The power in a frequency band is defined by the area under the curve of the non-log-transformed PSD. For more details, please refer to https://raphaelvallat.com/bandpower.html.\n",
     "\n",
-    "Here again, YASA provides a convenient function ([bandpower_from_psd](https://raphaelvallat.github.io/yasa/generated/yasa.bandpower_from_psd.html#yasa.bandpower_from_psd)) to extract the average bandpower in specified bands from a pre-computed PSD."
+    "Here again, YASA provides a convenient function ([bandpower_from_psd](https://yasa-sleep.org/generated/yasa.bandpower_from_psd.html#yasa.bandpower_from_psd)) to extract the average bandpower in specified bands from a pre-computed PSD."
    ]
   },
   {
@@ -623,7 +623,7 @@
     "\n",
     "## A one-liner function\n",
     "\n",
-    "The above is great, but calculating the hypnogram mask and the PSD of data manually every time seems a bit tedious. Can we wrap all that into a single function? The good news is that, yes, you can directly apply the [bandpower](https://raphaelvallat.github.io/yasa/generated/yasa.bandpower.html#yasa.bandpower) function to raw EEG data (in numpy or MNE format), which will automatically run all the previous steps for you. In other words, the function will:\n",
+    "The above is great, but calculating the hypnogram mask and the PSD of data manually every time seems a bit tedious. Can we wrap all that into a single function? The good news is that, yes, you can directly apply the [bandpower](https://yasa-sleep.org/generated/yasa.bandpower.html#yasa.bandpower) function to raw EEG data (in numpy or MNE format), which will automatically run all the previous steps for you. In other words, the function will:\n",
     "\n",
     "1. Calculate an hypnogram mask, if wanted\n",
     "2. Calculate the Welch's PSD for each channel, and, if applicable, each sleep stage\n",
@@ -2163,7 +2163,7 @@
     "\n",
     "## To higher dimensions and beyond!\n",
     "\n",
-    "Now, let's say that we're working with higher dimensions of data, such as for example a 3-D array of shape `(n_epochs, n_chan, n_samples)`. For instance, this can be the case if you use the [yasa.sliding_window](https://raphaelvallat.github.io/yasa/generated/yasa.sliding_window.html) function to segment 2-D data into 30-seconds epochs, as illustrated below."
+    "Now, let's say that we're working with higher dimensions of data, such as for example a 3-D array of shape `(n_epochs, n_chan, n_samples)`. For instance, this can be the case if you use the [yasa.sliding_window](https://yasa-sleep.org/generated/yasa.sliding_window.html) function to segment 2-D data into 30-seconds epochs, as illustrated below."
    ]
   },
   {
@@ -2195,7 +2195,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* The first dimension of ``data`` corresponds to the 98 epochs that were extracted from the data using the [yasa.sliding_window](https://raphaelvallat.github.io/yasa/generated/yasa.sliding_window.html) function.\n",
+    "* The first dimension of ``data`` corresponds to the 98 epochs that were extracted from the data using the [yasa.sliding_window](https://yasa-sleep.org/generated/yasa.sliding_window.html) function.\n",
     "* The second dimension is the 6 channels.\n",
     "* The last dimension refers to the number of samples present in each window (30-seconds @ 100 Hz: 3000 data points).\n",
     "\n",

--- a/notebooks/10_spectrogram.ipynb
+++ b/notebooks/10_spectrogram.ipynb
@@ -120,7 +120,7 @@
     "\n",
     "Next, we load the sleep staging vector (a.k.a hypnogram), which is a simple text file in which each value represents 30 seconds of data. Sleep stages are encoded as integer (*0: Wake, 1: N1 sleep, 2: N2 sleep, 3: N3 sleep, 4: REM sleep*).\n",
     "\n",
-    "In the code below, we load our 30-sec hypnogram and upsample it to match the sampling frequency and length of data, using YASA's built-in [hypno_upsample_to_data](https://raphaelvallat.github.io/yasa/generated/yasa.hypno_upsample_to_data.html#yasa.hypno_upsample_to_data) function.\n",
+    "In the code below, we load our 30-sec hypnogram and upsample it to match the sampling frequency and length of data, using YASA's built-in [hypno_upsample_to_data](https://yasa-sleep.org/generated/yasa.hypno_upsample_to_data.html#yasa.hypno_upsample_to_data) function.\n",
     "\n",
     "Please refer to [08_bandpower.ipynb](08_bandpower.ipynb) for more details on how to manipulate hypnogram in YASA."
    ]

--- a/notebooks/12_SO-sigma_coupling.ipynb
+++ b/notebooks/12_SO-sigma_coupling.ipynb
@@ -117,7 +117,7 @@
     "\n",
     "> *For event-locked cross-frequency analyses (Dvorak and Fenton, 2014; Staresina et al.,2015; Helfrich et al., 2018), the normalized SO trough-locked data were first filtered into the SO component (0.1–1.25 Hz), and then the instantaneous phase angle was extracted after applying a Hilbert transform. Then the same trials were filtered between 12 and 16 Hz, and the instantaneous amplitude was extracted from the Hilbert transform. Only the time range from 2 to 2 s was considered, to avoid filter edge artifacts. For every subject, channel, and epoch, the maximal sleep spindle amplitude and corresponding SO phase angle were detected. The mean circular direction and resultant vector length across all NREM events were determined using the CircStat toolbox(Berens, 2009).*\n",
     "\n",
-    "YASA provides some convenient tools to automatize these steps. Specifically, the ``coupling`` and ``coupling_params`` parameters of the [yasa.sw_detect](https://raphaelvallat.github.io/yasa/generated/yasa.sw_detect.html) allows us to replicate these exact same steps:"
+    "YASA provides some convenient tools to automatize these steps. Specifically, the ``coupling`` and ``coupling_params`` parameters of the [yasa.sw_detect](https://yasa-sleep.org/generated/yasa.sw_detect.html) allows us to replicate these exact same steps:"
    ]
   },
   {
@@ -450,7 +450,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As explained in the documentation of the [yasa.sw_detect](https://raphaelvallat.github.io/yasa/generated/yasa.sw_detect.html), we get some additional columns in the output dataframe:\n",
+    "As explained in the documentation of the [yasa.sw_detect](https://yasa-sleep.org/generated/yasa.sw_detect.html), we get some additional columns in the output dataframe:\n",
     "\n",
     "1) The ``SigmaPeak`` column contains the timestamp (in seconds from the beginning of the recording) where the sigma-filtered (12 - 16 Hz, see ``freq_sp``) amplitude is at its maximal. This is calculated separately for each detected slow-wave, using a **4-seconds epoch centered around the negative peak of the slow-wave**. Note that the duration of the epoch can be changed by specifying ``coupling_params['time']``.\n",
     "\n",

--- a/notebooks/14_automatic_sleep_staging.ipynb
+++ b/notebooks/14_automatic_sleep_staging.ipynb
@@ -516,7 +516,7 @@
    "source": [
     "## Sleep staging\n",
     "\n",
-    "Automatic sleep stages classification can be done since YASA 0.4.0 using the [SleepStaging](https://raphaelvallat.github.io/yasa/generated/yasa.SleepStaging.html#yasa.SleepStaging) class. Make sure to read the [documentation](https://raphaelvallat.github.io/yasa/generated/yasa.SleepStaging.html#yasa.SleepStaging), which explains how the algorithm works."
+    "Automatic sleep stages classification can be done since YASA 0.4.0 using the [SleepStaging](https://yasa-sleep.org/generated/yasa.SleepStaging.html#yasa.SleepStaging) class. Make sure to read the [documentation](https://yasa-sleep.org/generated/yasa.SleepStaging.html#yasa.SleepStaging), which explains how the algorithm works."
    ]
   },
   {

--- a/notebooks/15_topoplot.ipynb
+++ b/notebooks/15_topoplot.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Topoplot\n",
     "\n",
-    "The [yasa.topoplot](https://raphaelvallat.github.io/yasa/generated/yasa.topoplot.html) function is a wrapper around [mne.viz.plot_topomap](https://mne.tools/stable/generated/mne.viz.plot_topomap.html) function."
+    "The [yasa.topoplot](https://yasa-sleep.org/generated/yasa.topoplot.html) function is a wrapper around [mne.viz.plot_topomap](https://mne.tools/stable/generated/mne.viz.plot_topomap.html) function."
    ]
   },
   {

--- a/notebooks/16_EEG-HRV_coupling.ipynb
+++ b/notebooks/16_EEG-HRV_coupling.ipynb
@@ -456,7 +456,7 @@
     "\n",
     "### Calculate cardiovascular features\n",
     "\n",
-    "Using the [yasa.hrv_stage](https://raphaelvallat.github.io/yasa/generated/yasa.hrv_stage.html#yasa.hrv_stage) function, we can calculate heart rate and HRV in consecutive epochs of 2.5 minutes throughout the entire night. We get the following columns:\n",
+    "Using the [yasa.hrv_stage](https://yasa-sleep.org/generated/yasa.hrv_stage.html#yasa.hrv_stage) function, we can calculate heart rate and HRV in consecutive epochs of 2.5 minutes throughout the entire night. We get the following columns:\n",
     "\n",
     "- `start`: the start of the epoch, in seconds from the beginning of the recording\n",
     "- `duration`: the duration of the epoch, in this case it is always 150 seconds (2.5 min)\n",
@@ -693,7 +693,7 @@
    "source": [
     "### Calculate EEG powers\n",
     "\n",
-    "For each of these 2.5-min epochs, we now calculate the corresponding EEG sigma power. While this could be done with a for loop, here we leverage the [yasa.sliding_window](https://raphaelvallat.github.io/yasa/generated/yasa.sliding_window.html#yasa.sliding_window) function to convert our continuous EEG data into epochs of 2.5-minutes, and then calculate the bandpower on each epoch. Please see [08_bandpower.ipynb](https://github.com/raphaelvallat/yasa/blob/master/notebooks/08_bandpower.ipynb) for more details on the [yasa.bandpower](https://raphaelvallat.github.io/yasa/generated/yasa.bandpower.html#yasa.bandpower) function"
+    "For each of these 2.5-min epochs, we now calculate the corresponding EEG sigma power. While this could be done with a for loop, here we leverage the [yasa.sliding_window](https://yasa-sleep.org/generated/yasa.sliding_window.html#yasa.sliding_window) function to convert our continuous EEG data into epochs of 2.5-minutes, and then calculate the bandpower on each epoch. Please see [08_bandpower.ipynb](https://github.com/raphaelvallat/yasa/blob/master/notebooks/08_bandpower.ipynb) for more details on the [yasa.bandpower](https://yasa-sleep.org/generated/yasa.bandpower.html#yasa.bandpower) function"
    ]
   },
   {
@@ -1828,7 +1828,7 @@
     "- In NREM sleep, sigma power is the strongest predictor of heart rate. Specifically, higher sigma power is associated with lower heart rate. The strongest predictor of HRV is theta power, with higher theta predicting higher HRV (a good outcome).\n",
     "- In REM sleep, sigma power is the strongest predictor of both heart rate and HRV. Here, higher sigma is associated with a lower heart rate and a higher HRV, i.e. more restorative sleep. This is perhaps surprising since the sigma band is not typically associated with REM sleep.\n",
     "\n",
-    "There are many other ways that we could leverage YASA to calculate brain—body coupling. For example, [Mikutta et al 2021](https://onlinelibrary.wiley.com/doi/10.1111/jsr.13466) showed a correlation between slow oscillations—spindle coupling (and phase) and heart rate variability in NREM sleep. Also, changing some of the parameters of this analysis — such as the epoch length or the outlier rejection thresholds — may strongly impact the results. On the latter, the [yasa.hrv_stage](https://raphaelvallat.github.io/yasa/generated/yasa.hrv_stage.html#yasa.hrv_stage) function also returns the indices of all the detected ECG peaks, so we could easily apply a different outlier rejection method and/or calculate other relevant HRV metrics."
+    "There are many other ways that we could leverage YASA to calculate brain—body coupling. For example, [Mikutta et al 2021](https://onlinelibrary.wiley.com/doi/10.1111/jsr.13466) showed a correlation between slow oscillations—spindle coupling (and phase) and heart rate variability in NREM sleep. Also, changing some of the parameters of this analysis — such as the epoch length or the outlier rejection thresholds — may strongly impact the results. On the latter, the [yasa.hrv_stage](https://yasa-sleep.org/generated/yasa.hrv_stage.html#yasa.hrv_stage) function also returns the indices of all the detected ECG peaks, so we could easily apply a different outlier rejection method and/or calculate other relevant HRV metrics."
    ]
   }
  ],

--- a/src/yasa/features.py
+++ b/src/yasa/features.py
@@ -246,7 +246,7 @@ def compute_features_stage(
 
     # Detect spindles in N2 and N3
     # Thresholds have to be tuned with visual scoring of a subset of data
-    # https://raphaelvallat.github.io/yasa/generated/yasa.spindles_detect.html
+    # https://yasa-sleep.org/generated/yasa.spindles_detect.html
     sp = yasa.spindles_detect(raw_eeg, hypno=hypno, **spindles_params)
 
     df_sp = sp.summary(grp_chan=True, grp_stage=True).reset_index()

--- a/src/yasa/staging.py
+++ b/src/yasa/staging.py
@@ -66,7 +66,7 @@ class SleepStaging:
     We provide below some key points on the algorithm and its validation. For more details,
     we refer the reader to the peer-reviewed publication. If you have any questions,
     make sure to first check the
-    `FAQ section <https://raphaelvallat.github.io/yasa/faq.html>`_ of the documentation.
+    `FAQ section <https://yasa-sleep.org/faq.html>`_ of the documentation.
     If you did not find the answer to your question, please feel free to open an issue on GitHub.
 
     **1. Features extraction**
@@ -160,7 +160,7 @@ class SleepStaging:
 
     The sleep scores can then be manually edited in an external graphical user interface
     (e.g. EDFBrowser), as described in the
-    `FAQ <https://raphaelvallat.github.io/yasa/faq.html>`_.
+    `FAQ <https://yasa-sleep.org/faq.html>`_.
     """
 
     def __init__(self, raw, eeg_name, *, eog_name=None, emg_name=None, metadata=None):


### PR DESCRIPTION
[yasa-sleep.org](https://yasa-sleep.org) is now live! This PR replaces all the links. I also replaced the prefix for the 404 page as you suggested in #202. Can you please double check that this is right @remrama?

Edit: I compiled the doc and the 404 page is broken, so we will need to implement this:

> Note if there are issues between this setting and the relative/absolute path stuff and we end up needing for force a relative path for the static files, we can modify the 404 page HTML file after it's generated by this extension using a short function in config.py. I did this while testing and it also worked fine.

Do you have a code snippet to add to the `conf.py` file that I can integrate in this PR?

Thanks