### PR TITLE
Hypnogram: Add to_dict / from_dict and to_json / from_json methods

### DIFF
--- a/HYPNOGRAM_ROADMAP.md
+++ b/HYPNOGRAM_ROADMAP.md
@@ -31,6 +31,8 @@ Goal: make `yasa.Hypnogram` the industry-standard Python object for handling sle
 - `as_int()` — integer-encoded `pandas.Series`
 - `as_events()` — BIDS-compatible events `DataFrame` (onset, duration, stage)
 - `upsample(new_freq)` — change epoch resolution
+- `to_json(fname)` / `from_json(fname)` — save and load to disk, preserving all metadata
+- `to_dict()` / `from_dict(d)` — JSON-serializable in-memory representation (same format as `to_json`)
 
 ---
 
@@ -39,8 +41,6 @@ Goal: make `yasa.Hypnogram` the industry-standard Python object for handling sle
 ### I/O
 - **`to_csv()` / `from_csv()`** — round-trip to disk preserving metadata (freq, start, scorer, proba).
 - **`from_edf_annotations(raw)`** — load hypnogram from EDF+ annotations.
-- **`to_dict()` / `from_dict()`** — JSON-serializable representation.
-- **`to_json()` / `from_json()`** — round-trip to disk using JSON-serializable representation.
 
 
 ### Analysis

--- a/src/yasa/hypno.py
+++ b/src/yasa/hypno.py
@@ -48,7 +48,10 @@ class Hypnogram:
       detection, scorer agreement — are available as methods on the object itself.
 
     To create a ``Hypnogram`` from a legacy integer array, use :py:meth:`from_integers`.
-    To load a Compumedics Profusion file, use :py:meth:`from_profusion`.
+
+    To save a ``Hypnogram`` to disk, use :py:meth:`to_json`. The ``Hypnogram`` object and all
+    its metadata can then be reloaded with :py:meth:`from_json`. To work with an in-memory
+    dictionary instead, use :py:meth:`to_dict` and :py:meth:`from_dict`.
 
     .. versionadded:: 0.7.0
 
@@ -649,6 +652,74 @@ class Hypnogram:
         hypno_int = pd.Series(hypno_int).replace({4: 3, 5: 4}).to_numpy()
         return cls.from_integers(hypno_int, freq=freq, start=start, tz=tz, scorer=scorer)
 
+    @classmethod
+    def from_dict(cls, d):
+        """Reconstruct a :py:class:`Hypnogram` from a dictionary produced by :py:meth:`to_dict`.
+
+        All metadata is restored: epoch duration, start datetime (including timezone), scorer
+        name, and stage probabilities (if present).
+
+        .. versionadded:: 0.7.0
+
+        Parameters
+        ----------
+        d : dict
+            A dictionary with keys ``"values"``, ``"n_stages"``, ``"freq"``, ``"start"``,
+            ``"scorer"``, and ``"proba"``, as returned by :py:meth:`to_dict`.
+
+        Returns
+        -------
+        hyp : :py:class:`Hypnogram`
+            The reconstructed Hypnogram.
+
+        See Also
+        --------
+        to_dict : Return the Hypnogram as a JSON-serializable dictionary.
+        from_json : Load a :py:class:`Hypnogram` from a JSON file on disk.
+        """
+        start = pd.Timestamp(d["start"]) if d["start"] is not None else None
+        proba = pd.DataFrame(d["proba"]) if d["proba"] is not None else None
+        return cls(
+            values=d["values"],
+            n_stages=d["n_stages"],
+            freq=d["freq"],
+            start=start,
+            scorer=d["scorer"],
+            proba=proba,
+        )
+
+    @classmethod
+    def from_json(cls, fname):
+        """Load a :py:class:`Hypnogram` from a JSON file saved with :py:meth:`to_json`.
+
+        All metadata is restored: epoch duration, start datetime (including timezone), scorer
+        name, and stage probabilities (if present).
+
+        This method delegates to :py:meth:`from_dict` for deserialization.
+
+        .. versionadded:: 0.7.0
+
+        Parameters
+        ----------
+        fname : str or path-like
+            Path to the JSON file.
+
+        Returns
+        -------
+        hyp : :py:class:`Hypnogram`
+            The loaded Hypnogram.
+
+        See Also
+        --------
+        from_dict : Reconstruct a :py:class:`Hypnogram` from an in-memory dictionary.
+        to_json : Save the Hypnogram to a JSON file on disk.
+        """
+        import json
+
+        with open(fname) as f:
+            data = json.load(f)
+        return cls.from_dict(data)
+
     @property
     def hypno(self):
         """
@@ -969,6 +1040,64 @@ class Hypnogram:
             scorer=self.scorer,
             proba=self.proba,
         )
+
+    def to_dict(self):
+        """Return the Hypnogram as a JSON-serializable dictionary.
+
+        All metadata is preserved: epoch duration, start datetime (including timezone), scorer
+        name, and stage probabilities. Stage probabilities (``proba``) are rounded to 6 decimal
+        places.
+
+        The dictionary has the following keys: ``"values"``, ``"n_stages"``, ``"freq"``,
+        ``"start"``, ``"scorer"``, ``"proba"``. It can be passed to :py:meth:`from_dict` to
+        reconstruct the :py:class:`Hypnogram`.
+
+        .. versionadded:: 0.7.0
+
+        Returns
+        -------
+        d : dict
+            A JSON-serializable dictionary representing the Hypnogram and all its metadata.
+
+        See Also
+        --------
+        from_dict : Reconstruct a :py:class:`Hypnogram` from a dictionary.
+        to_json : Save the Hypnogram to a JSON file on disk.
+        """
+        return {
+            "values": self.hypno.to_numpy().tolist(),
+            "n_stages": self.n_stages,
+            "freq": self.freq,
+            "start": self.start.isoformat() if self.start is not None else None,
+            "scorer": self.scorer,
+            "proba": self.proba.round(6).to_dict(orient="list") if self.proba is not None else None,
+        }
+
+    def to_json(self, fname):
+        """Save the Hypnogram to a JSON file.
+
+        The file can be reloaded with :py:meth:`from_json`. All metadata is preserved: epoch
+        duration, start datetime (including timezone), scorer name, and stage probabilities.
+        Stage probabilities (``proba``) are rounded to 6 decimal places.
+
+        This method delegates to :py:meth:`to_dict` for serialization.
+
+        .. versionadded:: 0.7.0
+
+        Parameters
+        ----------
+        fname : str or path-like
+            Output file path. By convention, use a ``.json`` extension.
+
+        See Also
+        --------
+        to_dict : Return the same representation as an in-memory dictionary.
+        from_json : Reload the Hypnogram from a JSON file.
+        """
+        import json
+
+        with open(fname, "w") as f:
+            json.dump(self.to_dict(), f, indent=2)
 
     def crop(self, start=None, end=None):
         """Crop the hypnogram to a range of epochs or absolute timestamps.

--- a/tests/test_hypnoclass.py
+++ b/tests/test_hypnoclass.py
@@ -259,3 +259,121 @@ class TestHypnoClass(unittest.TestCase):
         # --- invalid integer (not in mapping) raises ---
         with pytest.raises(Exception):
             Hypnogram.from_integers([0, 99])
+
+    def test_json_roundtrip(self):
+        """Test that to_json / from_json preserves all metadata."""
+        import json
+        import os
+        import tempfile
+
+        stages = ["W", "W", "N1", "N2", "N3", "REM", "W"]
+
+        # Basic round-trip: no start, no scorer, no proba
+        hyp = Hypnogram(stages, freq="30s")
+        fd, fname = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        try:
+            hyp.to_json(fname)
+            hyp2 = Hypnogram.from_json(fname)
+            assert hyp2.freq == hyp.freq
+            assert hyp2.n_stages == hyp.n_stages
+            assert hyp2.start is None
+            assert hyp2.scorer is None
+            assert hyp2.proba is None
+            np.testing.assert_array_equal(hyp2.hypno.to_numpy(), hyp.hypno.to_numpy())
+        finally:
+            os.unlink(fname)
+
+        # With tz-aware start and scorer
+        hyp_ts = Hypnogram(
+            stages, freq="30s", start="2024-01-15 23:00:00", tz="UTC", scorer="Expert"
+        )
+        fd, fname = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        try:
+            hyp_ts.to_json(fname)
+            hyp_ts2 = Hypnogram.from_json(fname)
+            assert hyp_ts2.start == hyp_ts.start
+            assert hyp_ts2.scorer == "Expert"
+            assert hyp_ts2.start.tzinfo is not None  # tz preserved
+        finally:
+            os.unlink(fname)
+
+        # File is valid JSON
+        fd, fname = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        try:
+            hyp.to_json(fname)
+            with open(fname) as f:
+                parsed = json.load(f)
+            assert set(parsed.keys()) == {"values", "n_stages", "freq", "start", "scorer", "proba"}
+        finally:
+            os.unlink(fname)
+
+    def test_dict_roundtrip(self):
+        """Test that to_dict / from_dict preserves all metadata."""
+        stages = ["W", "W", "N1", "N2", "N3", "REM", "W"]
+
+        # Basic round-trip: no start, no scorer, no proba
+        hyp = Hypnogram(stages, freq="30s")
+        d = hyp.to_dict()
+        assert isinstance(d, dict)
+        assert set(d.keys()) == {"values", "n_stages", "freq", "start", "scorer", "proba"}
+        assert d["start"] is None
+        assert d["scorer"] is None
+        assert d["proba"] is None
+        assert d["values"] == list(hyp.hypno.to_numpy())
+        hyp2 = Hypnogram.from_dict(d)
+        assert hyp2.freq == hyp.freq
+        assert hyp2.n_stages == hyp.n_stages
+        assert hyp2.start is None
+        assert hyp2.scorer is None
+        assert hyp2.proba is None
+        np.testing.assert_array_equal(hyp2.hypno.to_numpy(), hyp.hypno.to_numpy())
+
+        # With tz-aware start and scorer
+        hyp_ts = Hypnogram(
+            stages, freq="30s", start="2024-01-15 23:00:00", tz="UTC", scorer="Expert"
+        )
+        d_ts = hyp_ts.to_dict()
+        assert d_ts["scorer"] == "Expert"
+        assert d_ts["start"] == "2024-01-15T23:00:00+00:00"  # isoformat with tz
+        hyp_ts2 = Hypnogram.from_dict(d_ts)
+        assert hyp_ts2.start == hyp_ts.start
+        assert hyp_ts2.scorer == "Expert"
+        assert hyp_ts2.start.tzinfo is not None
+
+        # to_dict and to_json produce identical serializable content
+        import json
+        import os
+        import tempfile
+
+        fd, fname = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        try:
+            hyp_ts.to_json(fname)
+            with open(fname) as f:
+                from_file = json.load(f)
+            assert from_file == hyp_ts.to_dict()
+        finally:
+            os.unlink(fname)
+
+        # proba round-trip and 6-decimal rounding
+        proba = pd.DataFrame(
+            {
+                "WAKE": [0.8, 0.1],
+                "N1": [0.1, 0.2],
+                "N2": [0.05, 0.4],
+                "N3": [0.03, 0.2],
+                "REM": [0.02, 0.1],
+            },
+        )
+        hyp_p = Hypnogram(["W", "N2"], freq="30s", proba=proba)
+        d_p = hyp_p.to_dict()
+        assert d_p["proba"] is not None
+        # All values rounded to ≤ 6 decimal places
+        for col_vals in d_p["proba"].values():
+            for v in col_vals:
+                assert v == round(v, 6)
+        hyp_p2 = Hypnogram.from_dict(d_p)
+        pd.testing.assert_frame_equal(hyp_p2.proba, hyp_p.proba.round(6), check_like=True)


### PR DESCRIPTION
**Serialization methods**

Add to_dict / from_dict and to_json / from_json methods to yasa.Hypnogram to support full round-trip serialization.                                                                                                                                                                                              
                                                            
- `to_dict()`: returns a JSON-serializable dictionary containing all hypnogram data and metadata (epoch duration, start datetime with timezone, scorer name, stage labels, and per-epoch stage probabilities). Stage probabilities are rounded to 6 decimal places.
- `from_dict(d)`: reconstructs a Hypnogram from a dictionary produced by to_dict.
- `to_json(fname)`: saves the hypnogram to a .json file on disk. Delegates to to_dict internally.
- `from_json(fname)`: loads a Hypnogram from a JSON file. Delegates to from_dict internally.

JSON is the recommended format for storing Hypnogram objects on disk: it is human-readable, preserves all metadata exactly, and is portable across platforms and tools. The format is identical whether using to_json (disk) or to_dict (in-memory), making it straightforward to integrate with APIs, databases, or custom storage backends.

**Tests**

Added test_dict_roundtrip covering basic round-trips, tz-aware start and scorer preservation, to_dict / to_json output identity, and proba precision rounding.
