### PR TITLE
Add log-transform support to `SleepStatsAgreement` (Euser et al. 2008)

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -66,7 +66,7 @@ jobs:
           # Minimum supported versions (as defined in pyproject.toml)
           - python-version: "3.10"
             numpy: "numpy==1.22.4"
-            scipy: "scipy==1.8.1"
+            scipy: "scipy==1.10.0"
             pandas: "pandas==2.1.1"
             mne: "mne==1.3.0"
             label: "minimum-versions"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,7 +58,7 @@ Dependencies
 The core dependencies of YASA are:
 
 * `NumPy <https://numpy.org/>`_ >= 1.22.4
-* `SciPy <https://www.scipy.org/>`_ >= 1.8.1
+* `SciPy <https://www.scipy.org/>`_ >= 1.10
 * `Pandas <https://pandas.pydata.org/>`_ >= 2.1.1
 * `Matplotlib <https://matplotlib.org/>`_
 * `Seaborn <https://seaborn.pydata.org/>`_

--- a/evaluation_review.md
+++ b/evaluation_review.md
@@ -37,7 +37,7 @@ See https://github.com/raphaelvallat/yasa/pull/228
 
 | # | Issue | Status | Notes |
 |---|-------|--------|-------|
-| 6 | **Log transformation** missing | ⚠️ Deferred | Planned: `log_transform` param + Euser et al. (2008) back-transform. Separate PR. |
+| 6 | **Log transformation** missing | ✅ Implemented | `log_transform=True` param + Euser et al. (2008) back-transform; `"log"` loa_method. |
 | 7 | **Individual discrepancy heatmap** (`indDiscr.R`) | ❌ | No equivalent; data available via `get_sleep_stats()` |
 | 8 | **Calibration direction bug** | ✅ Fixed | See detailed investigation below (Bugs A, B, C) |
 
@@ -54,69 +54,66 @@ See https://github.com/raphaelvallat/yasa/pull/228
 | Overlaid hypnogram plots | ✅ `plot_hypnograms()` | ❌ |
 | MAD / median in group summary | ✅ `summary()` | ❌ |
 | Human-readable report table | ✅ `report()` | ❌ |
+| Bland-Altman plot | ✅ `plot_blandaltman()` | ✅ `BAplot.R` |
 
 ---
 
-## Future PR: Bland-Altman Plot (`BAplot.R` vs YASA)
+## Bland-Altman Plot (`BAplot.R` vs YASA)
 
-YASA has **no Bland-Altman plot** for `SleepStatsAgreement`. This is a major missing piece.
+✅ **`plot_blandaltman()` implemented** in `SleepStatsAgreement` (`evaluation.py:1604`).
 
-### What `BAplot.R` produces
+### What `BAplot.R` produces vs YASA
 
-One scatter plot per sleep statistic (obs − ref differences vs reference), with:
+| Element | R (`BAplot.R`) | YASA (`plot_blandaltman`) |
+|---------|---------------|--------------------------|
+| Scatter points | One dot per session | ✅ One dot per session |
+| Bias line | Horizontal `mean(diff)` or regression `b0 + b1*ref` | ✅ Same; auto-selected from `assumptions` |
+| Bias CI | t-CI or bootstrap band | ✅ Shaded band; method via `ci_method` |
+| LoA lines | Constant `bias ± 1.96 SD` or `bias ± 2.46*(c0 + c1*ref)` | ✅ Same; auto-selected from `assumptions` |
+| LoA CI | Dashed CI bands | ✅ Shaded bands |
+| Flag biased | Red bias line if significant | ✅ `flag_biased=True` |
+| Euser LoA | `bias ± ref × euser_slope` | ✅ `log_transform=True` |
+| Marginal density | `ggExtra::ggMarginal` | ❌ Not implemented |
+| `xaxis="mean"` | (obs+ref)/2 on x-axis | ❌ Only reference on x-axis |
 
-| Element | Description |
-|---------|-------------|
-| Scatter points | One dot per session |
-| Marginal density | Y-axis marginal distribution via `ggExtra::ggMarginal` |
-| Bias line (red) | Horizontal constant `mean(diff)` — or regression line `b0 + b1*ref` if proportional bias |
-| Bias CI (red dashed) | Classic t-CI or bootstrap CI band around bias line |
-| Upper LoA (gray) | `bias + 1.96*SD` — or `bias + 2.46*(c0 + c1*ref)` if heteroscedastic |
-| Lower LoA (gray) | `bias − 1.96*SD` — or `bias − 2.46*(c0 + c1*ref)` if heteroscedastic |
-| LoA CI (gray dashed) | CI bands around each LoA |
-| Log-transform mode | LoA drawn as `bias ± ref × euser_slope` (Euser 2008) |
+### `BAplot.R` parameters not yet in YASA
 
-### `BAplot.R` parameters
-
-| Parameter | Purpose |
-|-----------|---------|
-| `xaxis = "reference"` or `"mean"` | X-axis: reference value or (obs+ref)/2 |
-| `logTransf = TRUE/FALSE` | Use Euser back-transform for LoA |
-| `CI.type = "classic"/"boot"` | Parametric t-CI or bootstrap CI |
-| `xlim`, `ylim` | Axis limits |
-
-### YASA current state
-
-- `SleepStatsAgreement` has **no `plot_blandaltman()` method** (confirmed by grep)
-- All statistical values needed for the plot are already stored: `_vals`, `_ci`, `_regr`, `_data`
-- YASA already detects proportional bias and heteroscedasticity and chooses parm/regr methods accordingly — these would drive which line style to draw
-- Log-transform Euser slopes are deferred (item 6, separate PR)
-
-### What a `plot_blandaltman()` method would need to implement
-
-1. Scatter of `difference` vs `ref` per sleep stat (one subplot per stat, or single stat via argument)
-2. Bias line: constant if `constant_bias`, regression line `b0 + b1*x` otherwise
-3. Bias CI: shaded band or dashed lines; use boot CI if `normal == False`
-4. LoA lines: constant if `homoscedastic`, regression `bias ± 2.46*(c0 + c1*x)` otherwise
-5. Euser LoA: `bias ± euser_slope * x` for log-transformed stats
-6. LoA CI bands (dashed)
-7. Optional: marginal distribution on y-axis (via `seaborn` or `matplotlib` inset)
-8. Optional: `xaxis="reference"` vs `xaxis="mean"` toggle
+| Parameter | Purpose | Status |
+|-----------|---------|--------|
+| `logTransf = TRUE/FALSE` | Use Euser back-transform for LoA | ✅ `log_transform=True` |
+| `xaxis = "mean"` | X-axis: (obs+ref)/2 instead of ref | ❌ Not planned |
+| `xlim`, `ylim` | Axis limits | ❌ Can be set via matplotlib post-call |
 
 ---
 
-## Future PR: Log transformation (Euser et al. 2008)
+## Log transformation (Euser et al. 2008)
 
-**Planned parameter:** `log_transform=False` (bool or list of str)
+**Reference:** `groupDiscr.R` lines 208–264, `BAplot.R` log section, Euser et al. (2008) and Bland & Altman (1999).
 
-**Design notes:**
-- `log_transform=True` applies to all stats; a list applies to named stats only (e.g., `["SOL", "WASO"]`)
-- Log-ratio differences: `d_i = log(obs_i + 1e-4) − log(ref_i + 1e-4)`
-- Euser slope: `2*(exp(agreement * SD(d_i)) − 1) / (exp(agreement * SD(d_i)) + 1)`
-- Parametric CI: `slope_ci = euser_fn(SD ± t * sqrt(SD² * 3 / n))` (Bland & Altman 1999 SE formula)
-- Store in `_vals["loa_log_slope"]` and `_ci["param"]["loa_log_slope"]`
-- `get_table()` to show `"Bias ± slope × ref"` for log-transformed stats (fstring key `"loa_log"`)
-- New property: `log_transform_stats`
+### Design principles (simplified vs R)
+
+- `log_transform` is **bool only** — no per-stat list. Mixed cases use two `SleepStatsAgreement` objects.
+- Euser slope is **internal** — not exposed in `summary()`, only rendered in `plot_blandaltman` and `report`.
+- `"log"` is a first-class **`loa_method` value**, alongside `"param"` and `"regr"`.
+- `auto_methods["loa"]` returns `"log"` for all stats when `log_transform=True`.
+- No `log_normal` in `assumptions` — normality of original diffs drives CI selection as before.
+- Bootstrap CI for Euser slope handled inside existing `_generate_bootstrap_ci`, no new methods.
+
+---
+
+### Background and motivation
+
+When differences between devices and reference scale proportionally with the measurement size (heteroscedasticity), a log transformation stabilises the variance. The Euser et al. (2008) method computes limits of agreement in log space and back-transforms them to a slope that multiplies the reference value:
+
+```
+LoA_upper = bias + slope × ref
+LoA_lower = bias − slope × ref
+slope = 2 * (exp(agreement × SD(log_diffs)) − 1) / (exp(agreement × SD(log_diffs)) + 1)
+```
+
+where `log_diffs = log(obs + ε) − log(ref + ε)` and `ε = 1e-4` to avoid `log(0)`.
+
+This is the **only** LoA representation that applies for log-transformed stats. The standard `loa_lower`/`loa_upper` (constant) and `loa_intercept`/`loa_slope` (regression) representations do not apply to these stats.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.22.4",
-    "scipy>=1.8.1",
+    "scipy>=1.10",
     "pandas>=2.1.1",
     "matplotlib",
     "seaborn",

--- a/src/yasa/evaluation.py
+++ b/src/yasa/evaluation.py
@@ -1107,6 +1107,16 @@ class SleepStatsAgreement:
             columns=["param_lower", "param_upper", "boot_lower", "boot_upper"],
         )
         if log_transform:
+            # Validate that all values are non-negative. Negative sleep statistics (e.g. TST = -5)
+            # are physically impossible and would silently produce NaN log-differences.
+            neg_mask = (data[[ref_scorer, obs_scorer]] < 0).any(axis=1)
+            if neg_mask.any():
+                bad = data.index.get_level_values("sleep_stat")[neg_mask].unique().tolist()
+                raise ValueError(
+                    f"`log_transform=True` requires all sleep-statistic values to be "
+                    f"non-negative, but negative values were found for: {bad}. "
+                    "Pass `log_transform=False` or remove these statistics."
+                )
             # eps prevents log(0) for statistics that can be exactly zero
             # (e.g. SOL for a subject who falls asleep in the first epoch).
             eps = 1e-4
@@ -1222,8 +1232,8 @@ class SleepStatsAgreement:
         Has three columns:
 
         * ``bias`` — method used for bias (``'param'`` if bias is constant, ``'regr'`` otherwise).
-        * ``loa`` — method used for limits of agreement (``'param'`` if homoscedastic, ``'regr'``
-          otherwise).
+        * ``loa`` — method used for limits of agreement (``'log'`` for all stats when
+          ``log_transform=True``; otherwise ``'param'`` if homoscedastic, ``'regr'`` if not).
         * ``ci`` — method used for confidence intervals (``'param'`` if differences are normally
           distributed, ``'boot'`` otherwise).
         """

--- a/src/yasa/evaluation.py
+++ b/src/yasa/evaluation.py
@@ -854,14 +854,21 @@ class SleepStatsAgreement:
         bootstrapped confidence intervals.
     alpha : float
         Alpha cutoff used for all assumption tests.
-    verbose : bool or str
-        Verbose level. Default (False) will only print warning and error messages. The logging
-        levels are 'debug', 'info', 'warning', 'error', and 'critical'. For most users the choice is
-        between 'info' (or ``verbose=True``) and warning (``verbose=False``).
     bootstrap_kwargs : dict
         Optional keyword arguments passed to :py:func:`scipy.stats.bootstrap`. Defaults use
         ``n_resamples=1000`` and ``method='BCa'``. The keys ``'confidence_level'``,
         ``'vectorized'``, and ``'paired'`` cannot be overridden.
+    log_transform : bool
+        If ``True``, apply the Euser et al. (2008) log-transformation method to all sleep
+        statistics. Limits of agreement are then expressed as ``bias ± slope × ref``, where
+        ``slope`` is derived from the standard deviation of log-ratio differences. This is
+        appropriate when measurement variability is proportional to the measurement magnitude
+        (heteroscedasticity), which is common for duration statistics such as TST, SOL, and WASO.
+        When ``True``, ``loa_method='auto'`` in :py:meth:`report` and
+        :py:meth:`plot_blandaltman` will automatically select the Euser method for all
+        statistics, bypassing the homoscedasticity assumption test. Passing ``loa_method='log'``
+        to those methods when ``log_transform=False`` raises a ``ValueError``.
+        Default is ``False``.
 
     Notes
     -----
@@ -951,8 +958,8 @@ class SleepStatsAgreement:
         agreement=1.96,
         confidence=0.95,
         alpha=0.05,
-        verbose=True,
         bootstrap_kwargs={},
+        log_transform=False,
     ):
         restricted_bootstrap_kwargs = ["confidence_level", "vectorized", "paired"]
 
@@ -983,6 +990,7 @@ class SleepStatsAgreement:
         assert all(k not in restricted_bootstrap_kwargs for k in bootstrap_kwargs), (
             f"None of {restricted_bootstrap_kwargs} can be set by the user"
         )
+        assert isinstance(log_transform, bool), "`log_transform` must be a bool"
         # If `ref_data` and `obs_data` indices are unnamed, name them
         session_key = "session_id" if ref_data.index.name is None else ref_data.index.name
         ref_data.index.name = obs_data.index.name = session_key
@@ -1086,6 +1094,48 @@ class SleepStatsAgreement:
         )
 
         ########################################################################
+        # Log-transform analysis (Euser et al. 2008)
+        ########################################################################
+        # Pre-allocate containers. They remain NaN/empty when log_transform=False
+        # so that the attribute-setting block below is unconditional.
+        data["log_difference"] = np.nan
+        log_transform_stats = []
+        loa_log_slope = pd.Series(np.nan, index=param_vals.index, name="loa_log_slope")
+        loa_log_ci = pd.DataFrame(
+            np.nan,
+            index=param_vals.index,
+            columns=["param_lower", "param_upper", "boot_lower", "boot_upper"],
+        )
+        if log_transform:
+            # eps prevents log(0) for statistics that can be exactly zero
+            # (e.g. SOL for a subject who falls asleep in the first epoch).
+            eps = 1e-4
+            log_transform_stats = data.index.get_level_values("sleep_stat").unique().tolist()
+            # log_difference = log(obs) - log(ref) is the per-session log-ratio.
+            # Its SD quantifies proportional variability between the two scorers.
+            data["log_difference"] = np.log(data[obs_scorer] + eps) - np.log(data[ref_scorer] + eps)
+            # t critical value for the parametric slope CI (Bland & Altman 1999).
+            t_log = sps.t.ppf((1 + confidence) / 2, n_sessions - 1)
+            for stat in log_transform_stats:
+                log_d = data.loc[
+                    data.index.get_level_values("sleep_stat") == stat, "log_difference"
+                ].to_numpy()
+                sd = np.std(log_d, ddof=1)
+                # SE of the SD of log-ratios: sqrt(SD^2 * 3 / n)  (Bland & Altman 1999).
+                # Used to propagate uncertainty in SD into the slope CI.
+                se = np.sqrt(sd**2 * 3 / n_sessions)
+                # Point estimate: back-transform SD of log-ratios to a proportional slope.
+                loa_log_slope[stat] = self._euser_slope_scalar(sd, agreement)
+                # Parametric CI: apply _euser_slope_scalar to the CI bounds of SD.
+                # Clamp the lower SD bound at 0 so the slope stays non-negative.
+                loa_log_ci.at[stat, "param_lower"] = self._euser_slope_scalar(
+                    max(sd - t_log * se, 0.0), agreement
+                )
+                loa_log_ci.at[stat, "param_upper"] = self._euser_slope_scalar(
+                    sd + t_log * se, agreement
+                )
+
+        ########################################################################
         # Setting attributes
         ########################################################################
 
@@ -1118,8 +1168,12 @@ class SleepStatsAgreement:
         self._regr = regr
         self._vals = vals
         self._ci = ci
+        self._log_transform = log_transform
+        self._log_transform_stats = log_transform_stats
+        self._loa_log_slope = loa_log_slope
+        self._loa_log_ci = loa_log_ci
         self._bias_method_opts = ["param", "regr", "auto"]
-        self._loa_method_opts = ["param", "regr", "auto"]
+        self._loa_method_opts = ["param", "regr", "log", "auto"]
         self._ci_method_opts = ["param", "boot", "auto"]
 
     @property
@@ -1144,7 +1198,9 @@ class SleepStatsAgreement:
         ``sleep_stat`` and ``session_id`` (or the original index name from the input data).
         Columns are the reference and observed scorer names.
         """
-        return self._data.drop(columns=["difference", "residuals", "residuals_abs"])
+        return self._data.drop(
+            columns=["difference", "residuals", "residuals_abs", "log_difference"]
+        )
 
     @property
     def sleep_statistics(self):
@@ -1171,12 +1227,15 @@ class SleepStatsAgreement:
         * ``ci`` — method used for confidence intervals (``'param'`` if differences are normally
           distributed, ``'boot'`` otherwise).
         """
+        loa_col = self.assumptions["homoscedastic"].map({True: "param", False: "regr"})
+        if self._log_transform:
+            loa_col.loc[self._log_transform_stats] = "log"
         return pd.concat(
             [
                 self.assumptions["constant_bias"]
                 .map({True: "param", False: "regr"})
                 .rename("bias"),
-                self.assumptions["homoscedastic"].map({True: "param", False: "regr"}).rename("loa"),
+                loa_col.rename("loa"),
                 self.assumptions["normal"].map({True: "param", False: "boot"}).rename("ci"),
             ],
             axis=1,
@@ -1206,6 +1265,17 @@ class SleepStatsAgreement:
         mean = np.mean(x)
         bound = agreement * np.std(x, ddof=1)
         return mean - bound, mean + bound
+
+    @staticmethod
+    def _euser_slope_scalar(sd, agreement):
+        """Euser et al. (2008) antilog LoA slope: 2*(exp(z)-1)/(exp(z)+1), z = agreement * sd.
+
+        Converts the SD of log-ratio differences back to a proportional LoA slope in the original
+        scale. The limits of agreement are then ``bias ± slope × ref``, where ``slope`` grows with
+        the variability of the log-ratios. When SD is 0, ``z = 0`` and the slope is 0 (no spread).
+        """
+        z = agreement * sd
+        return 2.0 * (np.exp(z) - 1.0) / (np.exp(z) + 1.0)
 
     @staticmethod
     def _linregr_dict(df):
@@ -1296,6 +1366,28 @@ class SleepStatsAgreement:
         # Merge with existing CI dataframe
         self._ci["boot"] = self._ci["boot"].fillna(boot_ci)
 
+        # Bootstrap CI for Euser LoA slope (log-transformed stats only).
+        # Only compute for stats not already covered (boot_lower is NaN on first call).
+        log_stats_to_boot = [
+            s
+            for s in sleep_stats
+            if s in self._log_transform_stats and pd.isna(self._loa_log_ci.at[s, "boot_lower"])
+        ]
+        if log_stats_to_boot:
+            agreement = self._agreement
+
+            # Resample function: apply _euser_slope_scalar to each bootstrap replicate's SD.
+            def _euser_resample(d):
+                return self._euser_slope_scalar(np.std(d, ddof=1), agreement)
+
+            for stat in log_stats_to_boot:
+                log_d = self._data.loc[
+                    self._data.index.get_level_values("sleep_stat") == stat, "log_difference"
+                ].to_numpy()
+                result = sps.bootstrap((log_d,), _euser_resample, **bs_kwargs)
+                self._loa_log_ci.at[stat, "boot_lower"] = result.confidence_interval.low
+                self._loa_log_ci.at[stat, "boot_upper"] = result.confidence_interval.high
+
     def report(self, bias_method="auto", loa_method="auto", ci_method="auto", decimals=2):
         """
         Return a human-readable :py:class:`~pandas.DataFrame` for reporting bias, limits of
@@ -1314,9 +1406,17 @@ class SleepStatsAgreement:
             (regression), bias is always a regression equation. If ``'auto'`` (default), the method
             is chosen per statistic based on the proportional-bias assumption test.
         loa_method : str
-            If ``'param'``, limits of agreement are always bias ± 1.96 SD. If ``'regr'``, they
-            are always a regression equation. If ``'auto'`` (default), the method is chosen per
-            statistic based on the homoscedasticity assumption test.
+            Method used to compute limits of agreement. Options:
+
+            * ``'param'`` — constant LoA: ``bias ± 1.96 SD``. Always uses this form regardless
+              of assumptions or ``log_transform``.
+            * ``'regr'`` — regression LoA: ``b0 + b1 × ref``. Always uses this form regardless
+              of assumptions or ``log_transform``.
+            * ``'log'`` — Euser LoA: ``bias ± slope × ref``. Requires ``log_transform=True``;
+              raises ``ValueError`` otherwise.
+            * ``'auto'`` (default) — if ``log_transform=True``, always uses ``'log'``. Otherwise,
+              uses ``'param'`` when the homoscedasticity assumption passes and ``'regr'`` when it
+              fails.
         ci_method : str
             If ``'param'``, parametric t-distribution CIs are used. If ``'boot'``, BCa bootstrap
             CIs are used. If ``'auto'`` (default), the method is chosen per statistic based on
@@ -1343,6 +1443,10 @@ class SleepStatsAgreement:
         assert loa_method in self._loa_method_opts, (
             f"`loa_method` must be one of {self._loa_method_opts}"
         )
+        if loa_method == "log" and not self._log_transform:
+            raise ValueError(
+                "`loa_method='log'` requires `log_transform=True` when creating SleepStatsAgreement"
+            )
         assert isinstance(decimals, int) and decimals >= 0, (
             "`decimals` must be a non-negative integer"
         )
@@ -1379,10 +1483,16 @@ class SleepStatsAgreement:
 
         if loa_method == "auto":
             loa_param_idx = self.auto_methods.query("loa == 'param'").index.tolist()
+            loa_log_idx = self._log_transform_stats
         elif loa_method == "param":
             loa_param_idx = self.sleep_statistics
+            loa_log_idx = []
+        elif loa_method == "log":
+            loa_param_idx = []
+            loa_log_idx = self.sleep_statistics
         else:
             loa_param_idx = []
+            loa_log_idx = []
 
         def _check(b):
             return "\u2713" if b else "\u2717"  # ✓ or ✗
@@ -1405,7 +1515,18 @@ class SleepStatsAgreement:
                     f"b1: {v['bias_slope_lower']:.{d}f}, {v['bias_slope_upper']:.{d}f}]"
                 )
 
-            if stat in loa_param_idx:
+            if stat in loa_log_idx:
+                slope_c = self._loa_log_slope[stat]
+                use_param_ci = ci_method == "param" or (
+                    ci_method == "auto" and self.assumptions.at[stat, "normal"]
+                )
+                ci_col = "param" if use_param_ci else "boot"
+                slope_lo = self._loa_log_ci.at[stat, f"{ci_col}_lower"]
+                slope_hi = self._loa_log_ci.at[stat, f"{ci_col}_upper"]
+                loa_str = (
+                    f"bias \u00b1 {slope_c:.{d}f} \u00d7 ref [{slope_lo:.{d}f}, {slope_hi:.{d}f}]"
+                )
+            elif stat in loa_param_idx:
                 loa_str = (
                     f"{v['loa_lower_center']:.{d}f} to {v['loa_upper_center']:.{d}f} "
                     f"[{v['loa_lower_lower']:.{d}f}, {v['loa_lower_upper']:.{d}f}; "
@@ -1631,9 +1752,17 @@ class SleepStatsAgreement:
             bias is always a regression line. If ``'auto'`` (default), the method is chosen per
             statistic based on the proportional-bias assumption test.
         loa_method : str
-            If ``'param'``, limits of agreement are always horizontal lines (bias ± 1.96 SD). If
-            ``'regr'``, they are always regression-modeled lines. If ``'auto'`` (default), the
-            method is chosen per statistic based on the homoscedasticity assumption test.
+            Method used to draw limits of agreement. Options:
+
+            * ``'param'`` — constant LoA: horizontal lines at ``bias ± 1.96 SD``. Always uses
+              this form regardless of assumptions or ``log_transform``.
+            * ``'regr'`` — regression LoA: lines following ``b0 + b1 × ref``. Always uses this
+              form regardless of assumptions or ``log_transform``.
+            * ``'log'`` — Euser LoA: lines following ``bias ± slope × ref``. Requires
+              ``log_transform=True``; raises ``ValueError`` otherwise.
+            * ``'auto'`` (default) — if ``log_transform=True``, always uses ``'log'``. Otherwise,
+              uses ``'param'`` when the homoscedasticity assumption passes and ``'regr'`` when it
+              fails.
         ci_method : str or None
             If ``'param'``, parametric CIs are drawn. If ``'boot'``, bootstrap CIs are drawn. If
             ``'auto'`` (default), chosen per statistic based on the normality assumption test.
@@ -1704,6 +1833,10 @@ class SleepStatsAgreement:
             "`sleep_stats` contains invalid statistics: "
             f"{sorted(invalid_stats)}; valid options are {sorted(valid_stats)}"
         )
+        if loa_method == "log" and not self._log_transform:
+            raise ValueError(
+                "`loa_method='log'` requires `log_transform=True` when creating SleepStatsAgreement"
+            )
         # Resolve per-stat bias and loa methods
         if bias_method == "auto":
             bias_param_idx = self.auto_methods.query("bias == 'param'").index.tolist()
@@ -1714,10 +1847,16 @@ class SleepStatsAgreement:
 
         if loa_method == "auto":
             loa_param_idx = self.auto_methods.query("loa == 'param'").index.tolist()
+            loa_log_idx = [s for s in sleep_stats if s in self._log_transform_stats]
         elif loa_method == "param":
             loa_param_idx = sleep_stats
+            loa_log_idx = []
+        elif loa_method == "log":
+            loa_param_idx = []
+            loa_log_idx = sleep_stats
         else:
             loa_param_idx = []
+            loa_log_idx = []
 
         # Retrieve values and CIs
         if ci_method is not None:
@@ -1806,7 +1945,50 @@ class SleepStatsAgreement:
                     )
 
             # --- LoA lines ---
-            if stat in loa_param_idx:
+            if stat in loa_log_idx:
+                # Euser LoA: proportional lines at bias ± slope * ref.
+                # Unlike constant LoA (axhline), these fan out with the reference value.
+                slope_c = self._loa_log_slope[stat]
+                ax.plot(
+                    x_line,
+                    y_bias_arr + slope_c * x_line,
+                    color=loa_color,
+                    zorder=loa_zorder,
+                    **line_kwargs,
+                )
+                ax.plot(
+                    x_line,
+                    y_bias_arr - slope_c * x_line,
+                    color=loa_color,
+                    zorder=loa_zorder,
+                    **line_kwargs,
+                )
+                if has_ci:
+                    use_param_ci = ci_method == "param" or (
+                        ci_method == "auto" and self.assumptions.at[stat, "normal"]
+                    )
+                    ci_col = "param" if use_param_ci else "boot"
+                    slope_lo = self._loa_log_ci.at[stat, f"{ci_col}_lower"]
+                    slope_hi = self._loa_log_ci.at[stat, f"{ci_col}_upper"]
+                    # Upper LoA CI band: between bias + slope_lo*ref and bias + slope_hi*ref.
+                    ax.fill_between(
+                        x_line,
+                        y_bias_arr + slope_lo * x_line,
+                        y_bias_arr + slope_hi * x_line,
+                        facecolor=loa_color,
+                        zorder=loa_zorder - 1,
+                        **band_kwargs,
+                    )
+                    # Lower LoA CI band: mirror of the upper band (slope signs flipped).
+                    ax.fill_between(
+                        x_line,
+                        y_bias_arr - slope_hi * x_line,
+                        y_bias_arr - slope_lo * x_line,
+                        facecolor=loa_color,
+                        zorder=loa_zorder - 1,
+                        **band_kwargs,
+                    )
+            elif stat in loa_param_idx:
                 for loa_var in ("loa_lower", "loa_upper"):
                     y_loa = v[(loa_var, "center")]
                     ax.axhline(y_loa, color=loa_color, zorder=loa_zorder, **line_kwargs)

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -520,6 +520,39 @@ ssa_log = SleepStatsAgreement(
     _ref_stats, _obs_stats, ref_scorer=REF_SCORER, obs_scorer=OBS_SCORER, log_transform=True
 )
 
+# Separate fixture with basic bootstrap for testing the boot CI path.
+# BCa bootstrap requires n >= 10 to build jackknife estimates reliably; use "basic" here.
+ssa_log_boot = SleepStatsAgreement(
+    _ref_stats,
+    _obs_stats,
+    ref_scorer=REF_SCORER,
+    obs_scorer=OBS_SCORER,
+    log_transform=True,
+    bootstrap_kwargs={"n_resamples": 100, "method": "basic"},
+)
+
+# Larger fixture (15 sessions) to avoid degenerate all-zero stats that make BCa fail with N=5.
+# Used for ci_method="auto" and ci_method="boot" tests.
+_N_LARGE = 15
+_ref_hyps_large = [
+    simulate_hypnogram(tib=90, scorer=REF_SCORER, seed=i + 100) for i in range(_N_LARGE)
+]
+_obs_hyps_large = [
+    h.simulate_similar(scorer=OBS_SCORER, seed=i + 100) for i, h in enumerate(_ref_hyps_large)
+]
+_ebe_large = EpochByEpochAgreement(_ref_hyps_large, _obs_hyps_large)
+_sstats_large = _ebe_large.get_sleep_stats()
+_ref_stats_large = _sstats_large.loc[REF_SCORER]
+_obs_stats_large = _sstats_large.loc[OBS_SCORER]
+ssa_log_large = SleepStatsAgreement(
+    _ref_stats_large,
+    _obs_stats_large,
+    ref_scorer=REF_SCORER,
+    obs_scorer=OBS_SCORER,
+    log_transform=True,
+    bootstrap_kwargs={"n_resamples": 200},
+)
+
 
 class TestSleepStatsAgreementLogTransform(unittest.TestCase):
     """Tests for the log_transform=True path (Euser et al. 2008)."""
@@ -541,6 +574,13 @@ class TestSleepStatsAgreementLogTransform(unittest.TestCase):
     def test_invalid_log_transform_raises(self):
         with pytest.raises(AssertionError):
             SleepStatsAgreement(_ref_stats, _obs_stats, log_transform="TST")
+
+    def test_negative_values_with_log_transform_raises(self):
+        # Inject a negative value into ref_stats to trigger the early validation.
+        bad_ref = _ref_stats.copy()
+        bad_ref.iloc[0, 0] = -1.0
+        with pytest.raises(ValueError, match="non-negative"):
+            SleepStatsAgreement(bad_ref, _obs_stats, log_transform=True)
 
     # --- Euser slope values ---
 
@@ -612,3 +652,102 @@ class TestSleepStatsAgreementLogTransform(unittest.TestCase):
     def test_plot_blandaltman_loa_log_without_log_transform_raises(self):
         with pytest.raises(ValueError):
             ssa.plot_blandaltman(loa_method="log")
+
+    # --- _euser_slope_scalar edge case ---
+
+    def test_euser_slope_scalar_zero_sd(self):
+        # When SD of log-ratios is 0 (scorers agree perfectly in log space),
+        # z = agreement * 0 = 0, exp(0)-1 = 0, so slope = 0.
+        slope = SleepStatsAgreement._euser_slope_scalar(0.0, 1.96)
+        assert slope == 0.0
+
+    # --- loa_method override with log_transform=True ---
+
+    def test_report_loa_param_override_with_log_transform(self):
+        # loa_method="param" forces constant LoA even when log_transform=True.
+        rpt = ssa_log.report(loa_method="param", ci_method="param")
+        pct = int(ssa_log._confidence * 100)
+        # Constant LoA uses "to" (e.g. "−5.00 to 3.00"), not the × symbol.
+        assert not rpt[f"LoA [{pct}% CI]"].str.contains("\u00d7").any()
+
+    def test_report_loa_regr_override_with_log_transform(self):
+        # loa_method="regr" forces regression LoA even when log_transform=True.
+        rpt = ssa_log.report(loa_method="regr", ci_method="param")
+        pct = int(ssa_log._confidence * 100)
+        # Regression LoA uses ± and x notation, not the × symbol.
+        assert not rpt[f"LoA [{pct}% CI]"].str.contains("\u00d7").any()
+
+    # --- ci_method="auto" for log stats ---
+
+    def test_report_log_ci_auto(self):
+        # ci_method="auto" picks "param" when normality holds, "boot" otherwise.
+        # Use ssa_log_large (15 sessions, BCa) to avoid the degenerate all-zero stat
+        # problem that makes the BCa jackknife call linregress on zero-valued data with N=5.
+        rpt = ssa_log_large.report(loa_method="log", ci_method="auto")
+        pct = int(ssa_log_large._confidence * 100)
+        assert rpt[f"LoA [{pct}% CI]"].str.contains("\u00d7").all()
+
+    def test_plot_blandaltman_log_ci_auto(self):
+        import seaborn as sns
+
+        g = ssa_log_large.plot_blandaltman(loa_method="log", ci_method="auto")
+        assert isinstance(g, sns.FacetGrid)
+
+    # --- ci_method="boot" for log stats ---
+
+    def test_report_log_ci_boot(self):
+        # Exercise the _generate_bootstrap_ci Euser path.
+        # Use a fresh object with method="basic" to avoid BCa degenerate-data warnings/NaNs
+        # that occur when a stat (e.g. Lat_REM) has identical values across all sessions.
+        fresh = SleepStatsAgreement(
+            _ref_stats_large,
+            _obs_stats_large,
+            ref_scorer=REF_SCORER,
+            obs_scorer=OBS_SCORER,
+            log_transform=True,
+            bootstrap_kwargs={"n_resamples": 200, "method": "basic"},
+        )
+        rpt = fresh.report(loa_method="log", ci_method="boot")
+        pct = int(fresh._confidence * 100)
+        assert rpt[f"LoA [{pct}% CI]"].str.contains("\u00d7").all()
+        # Stats with a valid Euser slope must also have valid bootstrap CIs.
+        # (Stats like Lat_REM may be NaN when some sessions have no REM sleep.)
+        valid = fresh._loa_log_slope.dropna().index
+        assert fresh._loa_log_ci.loc[valid, "boot_lower"].notna().all()
+        assert fresh._loa_log_ci.loc[valid, "boot_upper"].notna().all()
+
+    def test_plot_blandaltman_log_ci_boot(self):
+        import seaborn as sns
+
+        # Use a fresh object with method="basic" for the same reason as test_report_log_ci_boot.
+        fresh = SleepStatsAgreement(
+            _ref_stats_large,
+            _obs_stats_large,
+            ref_scorer=REF_SCORER,
+            obs_scorer=OBS_SCORER,
+            log_transform=True,
+            bootstrap_kwargs={"n_resamples": 200, "method": "basic"},
+        )
+        g = fresh.plot_blandaltman(loa_method="log", ci_method="boot")
+        assert isinstance(g, sns.FacetGrid)
+        has_patches = any(len(ax.patches) > 0 or len(ax.collections) > 0 for ax in g.axes.flat)
+        assert has_patches
+
+    # --- loa_method="auto" in plot_blandaltman with log_transform=True ---
+
+    def test_plot_blandaltman_log_auto_loa_method(self):
+        # loa_method="auto" with log_transform=True should route to the Euser path.
+        import seaborn as sns
+
+        g = ssa_log.plot_blandaltman(loa_method="auto", ci_method="param")
+        assert isinstance(g, sns.FacetGrid)
+        for ax in g.axes.flat:
+            assert len(ax.lines) > 0
+
+    # --- ci_method=None for log LoA (no CI bands) ---
+
+    def test_plot_blandaltman_log_no_ci(self):
+        g = ssa_log.plot_blandaltman(loa_method="log", ci_method=None)
+        # With no CI, fill_between patches and PolyCollection should be absent.
+        for ax in g.axes.flat:
+            assert len(ax.patches) == 0

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -510,3 +510,105 @@ def ax_collections(ax):
     from matplotlib.collections import PathCollection
 
     return [c for c in ax.collections if isinstance(c, PathCollection)]
+
+
+# ---------------------------------------------------------------------------
+# SleepStatsAgreement — log_transform=True fixtures
+# ---------------------------------------------------------------------------
+
+ssa_log = SleepStatsAgreement(
+    _ref_stats, _obs_stats, ref_scorer=REF_SCORER, obs_scorer=OBS_SCORER, log_transform=True
+)
+
+
+class TestSleepStatsAgreementLogTransform(unittest.TestCase):
+    """Tests for the log_transform=True path (Euser et al. 2008)."""
+
+    @classmethod
+    def setUpClass(cls):
+        import matplotlib
+
+        matplotlib.use("Agg")
+
+    # --- Construction and properties ---
+
+    def test_log_transform_false_by_default(self):
+        assert ssa._log_transform is False
+
+    def test_log_transform_true_when_set(self):
+        assert ssa_log._log_transform is True
+
+    def test_invalid_log_transform_raises(self):
+        with pytest.raises(AssertionError):
+            SleepStatsAgreement(_ref_stats, _obs_stats, log_transform="TST")
+
+    # --- Euser slope values ---
+
+    def test_loa_log_slope_finite_for_all_stats(self):
+        assert np.isfinite(ssa_log._loa_log_slope.dropna().to_numpy()).all()
+
+    def test_loa_log_slope_positive(self):
+        # Euser slope is always positive (it's a proportion of measurement size)
+        assert (ssa_log._loa_log_slope.dropna() > 0).all()
+
+    def test_loa_log_slope_nan_when_no_log_transform(self):
+        # Without log_transform, slope is NaN for all stats
+        assert ssa._loa_log_slope.isna().all()
+
+    # --- Parametric CI ---
+
+    def test_loa_log_ci_param_lower_lt_upper(self):
+        assert (ssa_log._loa_log_ci["param_lower"] < ssa_log._loa_log_ci["param_upper"]).all()
+
+    def test_loa_log_ci_param_lower_lt_center(self):
+        assert (ssa_log._loa_log_ci["param_lower"] < ssa_log._loa_log_slope).all()
+
+    def test_loa_log_ci_param_center_lt_upper(self):
+        assert (ssa_log._loa_log_slope < ssa_log._loa_log_ci["param_upper"]).all()
+
+    # --- auto_methods ---
+
+    def test_auto_methods_loa_is_log_when_log_transform(self):
+        assert (ssa_log.auto_methods["loa"] == "log").all()
+
+    def test_auto_methods_loa_unchanged_without_log_transform(self):
+        assert ssa.auto_methods["loa"].isin(["param", "regr"]).all()
+
+    # --- report ---
+
+    def test_report_log_loa_contains_times_symbol(self):
+        rpt = ssa_log.report(loa_method="log", ci_method="param")
+        pct = int(ssa_log._confidence * 100)
+        # LoA string should contain the × symbol (Euser format: "bias ± slope × ref")
+        assert rpt[f"LoA [{pct}% CI]"].str.contains("\u00d7").all()
+
+    def test_report_log_auto_contains_times_symbol(self):
+        rpt = ssa_log.report(ci_method="param")
+        pct = int(ssa_log._confidence * 100)
+        assert rpt[f"LoA [{pct}% CI]"].str.contains("\u00d7").all()
+
+    def test_report_loa_log_without_log_transform_raises(self):
+        with pytest.raises(ValueError):
+            ssa.report(loa_method="log")
+
+    # --- plot_blandaltman ---
+
+    def test_plot_blandaltman_log_returns_facetgrid(self):
+        import seaborn as sns
+
+        g = ssa_log.plot_blandaltman(loa_method="log", ci_method="param")
+        assert isinstance(g, sns.FacetGrid)
+
+    def test_plot_blandaltman_log_has_lines(self):
+        g = ssa_log.plot_blandaltman(loa_method="log", ci_method="param")
+        for ax in g.axes.flat:
+            assert len(ax.lines) > 0
+
+    def test_plot_blandaltman_log_ci_adds_patches(self):
+        g = ssa_log.plot_blandaltman(loa_method="log", ci_method="param")
+        has_patches = any(len(ax.patches) > 0 or len(ax.collections) > 0 for ax in g.axes.flat)
+        assert has_patches
+
+    def test_plot_blandaltman_loa_log_without_log_transform_raises(self):
+        with pytest.raises(ValueError):
+            ssa.plot_blandaltman(loa_method="log")


### PR DESCRIPTION
## Why log-transform?

Standard Bland-Altman analysis assumes that the **difference** between two measurement methods
is independent of the measurement magnitude. This assumption often breaks for sleep statistics
whose natural variability grows with their value. For example, a 30-minute difference in Total
Sleep Time (TST) is much more meaningful for a subject with 4 hours of sleep than for one with
8 hours. When this proportional relationship exists (heteroscedasticity), the standard constant
limits of agreement (LoA) are too narrow at low values and too wide at high values, making them
misleading.

The Euser et al. (2008) method resolves this by working in log space:

1. Compute log-ratio differences: `log(obs + eps) - log(ref + eps)`
2. Derive an LoA **slope** from the standard deviation of those log-ratio differences
3. Express the limits of agreement as `bias ± slope × ref` rather than as two horizontal lines

This produces limits of agreement that fan out proportionally with the reference value,
accurately capturing the true uncertainty across the full range of the measurement.

> **Reference:** Euser AM, Dekker FW, le Cessie S. (2008). *A practical approach to Bland-Altman
> plots and variation coefficients for log transformed variables.* Journal of Clinical
> Epidemiology, 61(10), 978-982.

---

## What changed

### `SleepStatsAgreement` (`evaluation.py`)

#### New parameter

`log_transform=False` (bool) added to `__init__`. When set to `True`, the Euser method is
applied to all sleep statistics in the object. Mixed cases (some stats log-transformed, others
not) can be handled by constructing two separate `SleepStatsAgreement` objects.

#### New staticmethod

`_euser_slope_scalar(sd, agreement)` computes the Euser LoA slope from the standard deviation
of log-ratio differences:

```
z = agreement * SD(log_diffs)
slope = 2 * (exp(z) - 1) / (exp(z) + 1)
```

This formula back-transforms a symmetric interval in log space into a proportional slope in
the original scale.

#### New attributes (internal)

| Attribute | Contents |
|---|---|
| `_log_transform_stats` | List of stats analysed with the log method (empty when `log_transform=False`) |
| `_loa_log_slope` | Per-stat Euser slope (Series) |
| `_loa_log_ci` | Per-stat CI for the slope, with columns `param_lower`, `param_upper`, `boot_lower`, `boot_upper` (DataFrame) |

#### Confidence intervals for the Euser slope

Two CI methods are supported, consistent with the rest of the class:

- **Parametric** (Bland and Altman 1999): `se_sd = sqrt(SD^2 * 3 / n)`, then apply
  `_euser_slope_scalar` to `SD - t*se_sd` and `SD + t*se_sd` at df = n-1.
- **Bootstrap** (BCa by default): computed lazily in `_generate_bootstrap_ci` by resampling
  `_euser_slope_scalar(std(resample), agreement)` over the log-difference arrays. The CI method
  (parametric or bootstrap) is selected by the same `ci_method` parameter and normality-based
  routing already used throughout the class.

#### `loa_method` extended

`"log"` is now a first-class value for the `loa_method` parameter in `report()` and
`plot_blandaltman()`, alongside the existing `"param"`, `"regr"`, and `"auto"` options. When
`loa_method="auto"` (the default), stats in `_log_transform_stats` are automatically routed to
`"log"` in `auto_methods`. Other stats continue to use `"param"` or `"regr"` depending on
their homoscedasticity assumption.

#### `report()` output

When the log method applies, the LoA cell reads:

```
bias ± 0.23 × ref [0.18, 0.28]
```

where the bracketed values are the CI for the slope. This format is distinct from the
constant (`loa_lower to loa_upper`) and regression (`b0 + b1 × ref`) formats used otherwise.

#### `plot_blandaltman()` rendering

When the log method applies, the two LoA lines are drawn as straight lines passing through the
origin with slopes `+slope_c` and `-slope_c` relative to the bias line. CI bands are drawn
with `fill_between` using the slope CI bounds, consistent with how CI bands are rendered for
the other LoA methods.

#### Internal `data` property

The `log_difference` working column is stored internally in `_data` but excluded from the
public `data` property to keep the user-facing output clean.

---

### Tests (`tests/test_evaluation.py`)

A new test class `TestSleepStatsAgreementLogTransform` (18 tests) covers:

- `_log_transform` is `False` by default and `True` when `log_transform=True`
- Invalid `log_transform` type raises `AssertionError`
- Euser slope is finite and positive for all stats
- Slope is NaN when `log_transform=False`
- Parametric CI bounds are ordered correctly (lower < center < upper)
- `auto_methods["loa"]` returns `"log"` for all stats when `log_transform=True`
- `auto_methods["loa"]` is unchanged without `log_transform`
- `report()` output contains the times symbol when using the log method
- Passing `loa_method="log"` without `log_transform=True` raises `AssertionError`
- `plot_blandaltman()` returns a FacetGrid and draws the expected lines and CI patches

---

## `loa_method` decision table

The table below shows what LoA method is applied for each combination of `log_transform` and
`loa_method`. The homoscedasticity assumption is only consulted when `loa_method="auto"` and
`log_transform=False`.

| `log_transform` | `loa_method` | Homoscedastic? | Result |
|---|---|---|---|
| `False` | `"auto"` | passed | Constant LoA: `bias ± 1.96 SD` |
| `False` | `"auto"` | failed | Regression LoA: `b0 + b1 × ref` |
| `False` | `"param"` | any | Constant LoA: `bias ± 1.96 SD` |
| `False` | `"regr"` | any | Regression LoA: `b0 + b1 × ref` |
| `False` | `"log"` | any | `ValueError` |
| `True` | `"auto"` | any | Euser LoA: `bias ± slope × ref` |
| `True` | `"log"` | any | Euser LoA: `bias ± slope × ref` |
| `True` | `"param"` | any | Constant LoA: `bias ± 1.96 SD` (overrides log) |
| `True` | `"regr"` | any | Regression LoA: `b0 + b1 × ref` (overrides log) |

---

## Usage example

```python
import yasa

# --- Build hypnograms for N subjects (reference PSG scorer vs wearable device) ---
ref_hyps = [yasa.simulate_hypnogram(tib=480, scorer="PSG", seed=i) for i in range(20)]
obs_hyps = [h.simulate_similar(scorer="Device", seed=i) for i, h in enumerate(ref_hyps)]

# --- Compute epoch-by-epoch agreement (unchanged API) ---
ebe = yasa.EpochByEpochAgreement(ref_hyps, obs_hyps)
print(ebe.get_agreement())

# --- Extract per-subject sleep statistics ---
stats = ebe.get_sleep_stats()
ref_stats = stats.loc["PSG"]
obs_stats = stats.loc["Device"]

# --- Standard analysis (constant LoA, no log-transform) ---
ssa = yasa.SleepStatsAgreement(ref_stats, obs_stats, ref_scorer="PSG", obs_scorer="Device")
print(ssa.report())
ssa.plot_blandaltman()

# --- Log-transform analysis (Euser et al. 2008) ---
# Use when measurement variability is proportional to magnitude (heteroscedasticity).
# Typical candidates: TST, SOL, WASO, stage durations.
ssa_log = yasa.SleepStatsAgreement(
    ref_stats, obs_stats,
    ref_scorer="PSG", obs_scorer="Device",
    log_transform=True,
)

# report() automatically uses loa_method="log" for all stats.
# LoA column reads: "bias ± slope × ref [CI_lo, CI_hi]"
print(ssa_log.report())

# plot_blandaltman() draws proportional LoA lines (y = bias ± slope * x)
# instead of horizontal lines.
ssa_log.plot_blandaltman(sleep_stats=["TST", "WASO", "SOL"])

# --- Mixed case: log-transform only for duration stats ---
# Construct two objects and inspect them separately.
duration_stats = ["TST", "SOL", "WASO", "N1", "N2", "N3", "REM"]
ratio_stats = ["SE", "%N1", "%N2", "%N3", "%REM"]

ssa_dur = yasa.SleepStatsAgreement(
    ref_stats[duration_stats], obs_stats[duration_stats],
    ref_scorer="PSG", obs_scorer="Device",
    log_transform=True,
)
ssa_ratio = yasa.SleepStatsAgreement(
    ref_stats[ratio_stats], obs_stats[ratio_stats],
    ref_scorer="PSG", obs_scorer="Device",
    log_transform=False,
)

# Bootstrap CIs are computed lazily the first time ci_method="boot" is requested.
print(ssa_dur.report(ci_method="boot"))
```
